### PR TITLE
build: ignore versioned 1-*.agones.dev URLs in htmltest

### DIFF
--- a/site/htmltest.yaml
+++ b/site/htmltest.yaml
@@ -27,6 +27,7 @@ IgnoreURLs:
   - https://github.com/agones-dev/agones/blob/main/docs/proposals
   - https://www.terraform.io/
   - https://repost\.aws/.*
+  - https://1-.*\.agones\.dev
 
 HTTPHeaders:
   User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/agones-dev/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/agones-dev/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/agones-dev/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

Site docs reference version-pinned URLs like https://1-59-0.agones.dev which currently have broken certs while we move the project. Add a regex ignore pattern matching those URLs.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
Use "Work on #<issue number>" if you wish to reference the issue without closing it.
-->
N/A


**Did you use AI tools in preparing this PR?**:
<!--
If you used AI tools in preparing your PR, you must disclose this in the description of your PR.
--->
Y

**Special notes for your reviewer**:

Unblocks CI
