### PR TITLE
build: enable gosec, correctness linters, and testifylint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,17 +28,32 @@ linters:
   # `default: standard` (the default) additionally enables errcheck, govet,
   # ineffassign, staticcheck and unused, so they are deliberately not listed here.
   enable:
+    - asasalint
+    - bidichk
     - bodyclose
     - copyloopvar
     - dupl
+    - durationcheck
+    - errname
+    - errorlint
+    - fatcontext
+    - gocheckcompilerdirectives
     - goconst
     - gocritic
     - gocyclo
+    - gosec
+    - makezero
     - misspell
     - nakedret
+    - nilerr
+    - nilnesserr
+    - noctx
+    - reassign
     - revive
+    - testifylint
     - unconvert
     - unparam
+    - wastedassign
   settings:
     goconst:
       # Table-driven tests repeat literals by nature; hoisting them into
@@ -53,6 +68,24 @@ linters:
         rangeValCopy:
           sizeThreshold: 512
           skipTestFuncs: true
+    gosec:
+      excludes:
+        # G104 is unhandled errors, which errcheck already reports, and errcheck
+        # understands the `//nolint:errcheck` directives already in the tree.
+        - G104
+        # G115 is integer overflow on conversion. The Kubernetes API types round
+        # int32 through int constantly, so this fires on ~370 conversions that
+        # are structurally safe. Triaging it is worthwhile but it needs its own
+        # pass -- bundling it here would bury every other gosec finding.
+        - G115
+    testifylint:
+      disable:
+        # require-error wants every assert.NoError that guards later statements
+        # rewritten as require.NoError. It is right about most of them, but it
+        # is ~330 call sites and changing whether a test aborts or continues is
+        # a behavioural change per site, not a mechanical one. Worth doing
+        # deliberately rather than as a side effect of turning the linter on.
+        - require-error
     govet:
       disable-all: false
       enable-all: true
@@ -96,6 +129,41 @@ linters:
       - path: (.+)_test\.go|^test/|^cmd/.*|^pkg/apis/.*
         # fieldalignment is in the `govet` linter, so exclude based on text instead of all of govet
         text: '^fieldalignment: .*'
+
+      # `wait.PollUntilContextTimeout` and friends take `(false, nil)` to mean
+      # "not ready, try again" -- returning the error instead aborts the poll.
+      # The e2e suite is built on that idiom, so nilerr fires on correct code
+      # there and would tax every new poll loop with a fresh suppression.
+      - path: (.+)_test\.go|^test/
+        linters: [nilerr]
+
+      # noctx wants every request, listener and dial to carry a context. That
+      # matters for the controllers, where cancellation has to propagate; in a
+      # test the enclosing `go test` timeout already bounds everything, so it
+      # would only buy a context.Background() argument on every call.
+      - path: (.+)_test\.go|^test/
+        linters: [noctx]
+
+      # Tests legitimately do the things gosec is looking for: weak RNG for
+      # fixtures (G404), reading files named by a variable (G304), permissive
+      # temp-dir permissions (G301/G306). None of it ships.
+      - path: (.+)_test\.go|^test/
+        linters: [gosec]
+
+      # build/ is developer tooling, run by a maintainer on their own machine
+      # against repo-local paths. It is not built into any container and never
+      # sees untrusted input, so the file-permission and file-inclusion rules
+      # have nothing to protect here.
+      - path: ^build/
+        linters: [gosec]
+
+      # The GenAI sample exists to relay player-authored text to an
+      # operator-supplied endpoint and log both sides of the conversation, so
+      # the SSRF (G704) and log-injection (G706) taint analysis flags its whole
+      # reason for existing. Kept enabled everywhere else.
+      - path: ^examples/
+        linters: [gosec]
+        text: '^G70[46]:'
 
     # which file paths to exclude: issues from them won't be reported
     paths:

--- a/build/report/report.go
+++ b/build/report/report.go
@@ -20,6 +20,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"html/template"
 	"log"
@@ -148,7 +149,7 @@ func main() {
 	it := c.ListBuilds(ctx, req)
 	for {
 		resp, err := it.Next()
-		if err == iterator.Done {
+		if errors.Is(err, iterator.Done) {
 			break
 		}
 		if err != nil {

--- a/cmd/allocator/main.go
+++ b/cmd/allocator/main.go
@@ -70,6 +70,12 @@ var (
 const (
 	certDir = "/home/allocator/client-ca/"
 	tlsDir  = "/home/allocator/tls/"
+
+	// readHeaderTimeout bounds how long a client may take to send its request
+	// headers. Without it a handful of connections trickling headers one byte
+	// at a time can hold the listener open indefinitely (Slowloris). It caps
+	// the headers only, so streaming request bodies are unaffected.
+	readHeaderTimeout = 60 * time.Second
 )
 
 const (
@@ -413,13 +419,15 @@ func runHTTP(listenCtx context.Context, workerCtx context.Context, h *serviceHan
 	if !h.mTLSDisabled {
 		cfg.ClientAuth = tls.RequireAnyClientCert
 		cfg.VerifyPeerCertificate = h.verifyClientCertificate
+		cfg.VerifyConnection = h.verifyClientConnection
 	}
 
 	// Create a Server instance to listen on the http port with the TLS config.
 	server := &http.Server{
-		Addr:      fmt.Sprintf(":%d", httpPort),
-		TLSConfig: cfg,
-		Handler:   handler,
+		Addr:              fmt.Sprintf(":%d", httpPort),
+		TLSConfig:         cfg,
+		Handler:           handler,
+		ReadHeaderTimeout: readHeaderTimeout,
 	}
 
 	go func() {
@@ -447,7 +455,7 @@ func runHTTP(listenCtx context.Context, workerCtx context.Context, h *serviceHan
 
 func runGRPC(ctx context.Context, h *serviceHandler, grpcHealth *grpchealth.Server, grpcPort int) {
 	logger.WithField("port", grpcPort).Info("Running the grpc handler on port")
-	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", grpcPort))
+	listener, err := (&net.ListenConfig{}).Listen(ctx, "tcp", fmt.Sprintf(":%d", grpcPort))
 	if err != nil {
 		logger.WithError(err).Fatalf("failed to listen on TCP port %d", grpcPort)
 		os.Exit(1)
@@ -615,6 +623,7 @@ func (h *serviceHandler) getGRPCServerOptions() []grpc.ServerOption {
 	if !h.mTLSDisabled {
 		cfg.ClientAuth = tls.RequireAnyClientCert
 		cfg.VerifyPeerCertificate = h.verifyClientCertificate
+		cfg.VerifyConnection = h.verifyClientConnection
 	}
 
 	return append([]grpc.ServerOption{grpc.Creds(credentials.NewTLS(cfg))}, opts...)
@@ -624,6 +633,27 @@ func (h *serviceHandler) getTLSCert(_ *tls.ClientHelloInfo) (*tls.Certificate, e
 	h.tlsMutex.RLock()
 	defer h.tlsMutex.RUnlock()
 	return h.tlsCert, nil
+}
+
+// verifyClientConnection re-runs client certificate verification for every
+// connection, including resumed ones.
+//
+// VerifyPeerCertificate only fires during a full handshake. A client that
+// completed one handshake can then resume its session indefinitely without the
+// certificate being looked at again -- so removing a CA from the watched
+// certDir would not actually lock out clients holding a valid session ticket.
+// VerifyConnection runs on resumption as well, which closes that gap.
+func (h *serviceHandler) verifyClientConnection(cs tls.ConnectionState) error {
+	if len(cs.PeerCertificates) == 0 {
+		return errors.New("no client certificate presented")
+	}
+
+	rawCerts := make([][]byte, 0, len(cs.PeerCertificates))
+	for _, cert := range cs.PeerCertificates {
+		rawCerts = append(rawCerts, cert.Raw)
+	}
+
+	return h.verifyClientCertificate(rawCerts, nil)
 }
 
 // verifyClientCertificate verifies that the client certificate is accepted
@@ -700,6 +730,8 @@ func getCACertPool(path string) (*x509.CertPool, error) {
 			continue
 		}
 		certFile := filepath.Join(path, dirEntry.Name())
+		//nolint:gosec // G304: certFile is joined from certDir, a compile-time
+		// constant, and a name listed by ReadDir of that same directory.
 		caCert, err := os.ReadFile(certFile)
 		if err != nil {
 			logger.Errorf("CA cert is not readable or missing: %s", err.Error())

--- a/cmd/allocator/main_test.go
+++ b/cmd/allocator/main_test.go
@@ -64,7 +64,7 @@ func TestAllocateHandler(t *testing.T) {
 	if !assert.True(t, ok) {
 		return
 	}
-	assert.Equal(t, st.Code(), codes.Aborted)
+	assert.Equal(t, codes.Aborted, st.Code())
 }
 
 func TestAllocateHandlerReturnsError(t *testing.T) {
@@ -86,22 +86,22 @@ func TestAllocateHandlerReturnsError(t *testing.T) {
 func TestGetTlsCert(t *testing.T) {
 	t.Parallel()
 	cert1, err := tls.X509KeyPair(serverCert1, serverKey1)
-	assert.Nil(t, err, "expected (serverCert1, serverKey1) to create a cert")
+	assert.NoError(t, err, "expected (serverCert1, serverKey1) to create a cert")
 
 	cert2, err := tls.X509KeyPair(serverCert2, serverKey2)
-	assert.Nil(t, err, "expected (serverCert2, serverKey2) to create a cert")
+	assert.NoError(t, err, "expected (serverCert2, serverKey2) to create a cert")
 
 	h := serviceHandler{
 		tlsCert: &cert1,
 	}
 
 	retrievedCert1, err := h.getTLSCert(nil)
-	assert.Nil(t, err, "expected getTlsCert() to not fail")
+	assert.NoError(t, err, "expected getTlsCert() to not fail")
 	assert.Equal(t, cert1.Certificate, retrievedCert1.Certificate, "expected the retrieved cert to be equal to the original one")
 
 	h.tlsCert = &cert2
 	retrievedCert2, err := h.getTLSCert(nil)
-	assert.Nil(t, err, "expected getTlsCert() to not fail")
+	assert.NoError(t, err, "expected getTlsCert() to not fail")
 	assert.Equal(t, cert2.Certificate, retrievedCert2.Certificate, "expected the retrieved cert to be equal to the original one")
 }
 
@@ -174,7 +174,7 @@ func TestVerifyClientCertificateSucceeds(t *testing.T) {
 
 	block, _ := pem.Decode(crt)
 	input := [][]byte{block.Bytes}
-	assert.Nil(t, h.verifyClientCertificate(input, nil),
+	assert.NoError(t, h.verifyClientCertificate(input, nil),
 		"verifyClientCertificate failed.")
 }
 
@@ -197,12 +197,12 @@ func TestGettingCaCert(t *testing.T) {
 	t.Parallel()
 
 	file, err := os.CreateTemp(".", "*.crt")
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		defer os.Remove(file.Name()) // nolint: errcheck
 		_, err = file.WriteString(clientCert)
-		if assert.Nil(t, err) {
+		if assert.NoError(t, err) {
 			certPool, err := getCACertPool("./")
-			if assert.Nil(t, err) {
+			if assert.NoError(t, err) {
 				// linting complaints certPool.Subjects() has been deprecated since Go 1.18.
 				// But since this cert doesn't come from SystemCertPool, it doesn't seem behavior
 				// should be impacted. So marking the lint as ignored.

--- a/cmd/ping/main.go
+++ b/cmd/ping/main.go
@@ -34,6 +34,10 @@ import (
 const (
 	httpResponseFlag = "http-response"
 	udpRateLimitFlag = "udp-rate-limit"
+
+	// readHeaderTimeout bounds how long a client may take to send its request
+	// headers, so a Slowloris client cannot hold the listener open indefinitely.
+	readHeaderTimeout = 60 * time.Second
 )
 
 var (
@@ -75,8 +79,9 @@ func serveHTTP(ctlConf config, h healthcheck.Handler) func() {
 	// we don't need a health checker, we already have a http endpoint that returns 200
 	mux := http.NewServeMux()
 	srv := &http.Server{
-		Addr:    ":8080",
-		Handler: mux,
+		Addr:              ":8080",
+		Handler:           mux,
+		ReadHeaderTimeout: readHeaderTimeout,
 	}
 
 	// add health check as well

--- a/cmd/ping/udp.go
+++ b/cmd/ping/udp.go
@@ -74,7 +74,7 @@ func (u *udpServer) run(ctx context.Context) {
 
 	logger.Info("Starting UDP server")
 	var err error
-	u.conn, err = net.ListenPacket("udp", ":8080")
+	u.conn, err = (&net.ListenConfig{}).ListenPacket(ctx, "udp", ":8080")
 	if err != nil {
 		logger.WithError(err).Fatal("Could not start udp server")
 	}
@@ -112,7 +112,7 @@ func (u *udpServer) readWriteLoop(ctx context.Context) {
 				b := make([]byte, 1024)
 				_, sender, err := u.conn.ReadFrom(b)
 				if err != nil {
-					if ctx.Err() != nil && err == os.ErrClosed {
+					if ctx.Err() != nil && errors.Is(err, os.ErrClosed) {
 						return
 					}
 					u.logger.WithError(err).Error("Error reading udp packet")

--- a/cmd/ping/udp_test.go
+++ b/cmd/ping/udp_test.go
@@ -43,7 +43,7 @@ func TestUDPServerVisit(t *testing.T) {
 
 	fc := testclocks.NewFakeClock(time.Now())
 	u, err := defaultFixture(fc)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer u.close()
 
 	// gate
@@ -75,7 +75,7 @@ func TestUDPServerCleanup(t *testing.T) {
 
 	fc := testclocks.NewFakeClock(time.Now())
 	u, err := defaultFixture(fc)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer u.close()
 
 	// gate
@@ -102,7 +102,7 @@ func TestUDPServerHealth(t *testing.T) {
 
 	fc := testclocks.NewFakeClock(time.Now())
 	u, err := defaultFixture(fc)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer u.close()
 
 	assert.Error(t, u.Health())
@@ -118,7 +118,7 @@ func TestUDPServerHealth(t *testing.T) {
 		return u.Health() != nil, nil
 	})
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func defaultFixture(cl clock.WithTickerAndDelayedExecution) (*udpServer, error) {

--- a/cmd/processor/main.go
+++ b/cmd/processor/main.go
@@ -325,7 +325,7 @@ func whenLeader(ctx context.Context, cancel context.CancelFunc, logger *logrus.E
 
 func runGRPC(ctx context.Context, h *processor.Handler, grpcHealth *grpchealth.Server, grpcPort int) {
 	logger.WithField("port", grpcPort).Info("Running the grpc handler on port")
-	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", grpcPort))
+	listener, err := (&net.ListenConfig{}).Listen(ctx, "tcp", fmt.Sprintf(":%d", grpcPort))
 	if err != nil {
 		logger.WithError(err).Fatalf("Failed to listen on TCP port %d", grpcPort)
 		os.Exit(1)

--- a/cmd/sdk-server/main.go
+++ b/cmd/sdk-server/main.go
@@ -51,6 +51,10 @@ const (
 	defaultHTTPPort   = 9358
 	defaultHealthPort = 8080
 
+	// readHeaderTimeout bounds how long a client may take to send its request
+	// headers, so a Slowloris client cannot hold the listener open indefinitely.
+	readHeaderTimeout = 60 * time.Second
+
 	// Flags (that can also be env vars)
 	gameServerNameFlag      = "gameserver-name"
 	podNamespaceFlag        = "pod-namespace"
@@ -100,8 +104,9 @@ func main() {
 
 	mux := runtime.NewServerMux()
 	httpServer := &http.Server{
-		Addr:    fmt.Sprintf("%s:%d", ctlConf.Address, ctlConf.HTTPPort),
-		Handler: wsproxy.WebsocketProxy(healthCheckWrapper(mux)),
+		Addr:              fmt.Sprintf("%s:%d", ctlConf.Address, ctlConf.HTTPPort),
+		Handler:           wsproxy.WebsocketProxy(healthCheckWrapper(mux)),
+		ReadHeaderTimeout: readHeaderTimeout,
 	}
 	defer httpServer.Close() // nolint: errcheck
 
@@ -177,7 +182,7 @@ func main() {
 	}
 
 	grpcEndpoint := fmt.Sprintf("%s:%d", ctlConf.Address, ctlConf.GRPCPort)
-	go runGrpc(grpcServer, grpcEndpoint)
+	go runGrpc(ctx, grpcServer, grpcEndpoint)
 	go runGateway(ctx, grpcEndpoint, mux, httpServer)
 
 	<-ctx.Done()
@@ -237,8 +242,8 @@ func registerTestSdkServer(grpcServer *grpc.Server, ctlConf config) (func(), err
 }
 
 // runGrpc runs the grpc service
-func runGrpc(grpcServer *grpc.Server, grpcEndpoint string) {
-	lis, err := net.Listen("tcp", grpcEndpoint)
+func runGrpc(ctx context.Context, grpcServer *grpc.Server, grpcEndpoint string) {
+	lis, err := (&net.ListenConfig{}).Listen(ctx, "tcp", grpcEndpoint)
 	if err != nil {
 		logger.WithField("grpcEndpoint", grpcEndpoint).Fatal("Could not listen on grpc endpoint")
 	}

--- a/examples/simple-genai-server/main.go
+++ b/examples/simple-genai-server/main.go
@@ -144,7 +144,7 @@ func main() {
 	if *simEndpoint == "" {
 		log.Printf("Creating GenAI Client at endpoint %s (from_id=%d, to_id=%d)", *genAiEndpoint, *fromID, *toID)
 		genAiConn := initClient(*genAiEndpoint, *genAiContext, "GenAI", *genAiNpc, *fromID, *toID)
-		go tcpListener(*port, genAiConn)
+		go tcpListener(sigCtx, *port, genAiConn)
 		<-sigCtx.Done()
 	} else {
 		var wg sync.WaitGroup
@@ -155,6 +155,7 @@ func main() {
 				defer wg.Done()
 				for {
 					// Create a random from_id and name
+					//nolint:gosec // G404: simulated player ids, not a security boundary.
 					fid := int(rand.Int31())
 					name := fmt.Sprintf("Sim%08x", fid)
 					log.Printf("=== New player %s (id %d) ===", name, fid)
@@ -263,26 +264,26 @@ func handleGenAIRequest(prompt string, clientConn *connection, chatHistory []Mes
 		jsonStr, err = json.Marshal(genAIRequest)
 	}
 	if err != nil {
-		return "", fmt.Errorf("unable to marshal json request: %v", err)
+		return "", fmt.Errorf("unable to marshal json request: %w", err)
 	}
 
-	req, err := http.NewRequest("POST", clientConn.endpoint, bytes.NewBuffer(jsonStr))
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, clientConn.endpoint, bytes.NewBuffer(jsonStr))
 	if err != nil {
-		return "", fmt.Errorf("unable create http POST request: %v", err)
+		return "", fmt.Errorf("unable create http POST request: %w", err)
 	}
 	req.Header.Set("accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := clientConn.client.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("unable to post request: %v", err)
+		return "", fmt.Errorf("unable to post request: %w", err)
 	}
 
 	defer resp.Body.Close() //nolint:errcheck // nothing actionable if closing the response body fails
 
 	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", fmt.Errorf("unable to read response body: %v", err)
+		return "", fmt.Errorf("unable to read response body: %w", err)
 	}
 	body := string(responseBody)
 
@@ -334,9 +335,9 @@ func autonomousChat(prompt string, conn1 *connection, conn2 *connection, numChat
 }
 
 // Manually interact via TCP with the GenAI endpoint
-func tcpListener(port string, genAiConn *connection) {
+func tcpListener(ctx context.Context, port string, genAiConn *connection) {
 	log.Printf("Starting TCP server, listening on port %s", port)
-	ln, err := net.Listen("tcp", ":"+port)
+	ln, err := (&net.ListenConfig{}).Listen(ctx, "tcp", ":"+port)
 	if err != nil {
 		log.Fatalf("Could not start TCP server: %v", err)
 	}

--- a/pkg/apis/agones/v1/common_test.go
+++ b/pkg/apis/agones/v1/common_test.go
@@ -163,7 +163,7 @@ func TestAllocationOverflowCountMatches(t *testing.T) {
 
 			count, rest := ao.CountMatches(list)
 			assert.Equal(t, v.expected.count, count, "count")
-			assert.Equal(t, v.expected.rest, len(rest), "rest")
+			assert.Len(t, rest, v.expected.rest, "rest")
 			for _, gs := range rest {
 				assert.Equal(t, GameServerStateAllocated, gs.Status.State)
 			}

--- a/pkg/apis/agones/v1/fleet_test.go
+++ b/pkg/apis/agones/v1/fleet_test.go
@@ -59,7 +59,7 @@ func TestFleetGameServerSetGameServer(t *testing.T) {
 	}
 
 	gsSet := f.GameServerSet()
-	assert.Equal(t, "", gsSet.ObjectMeta.Name)
+	assert.Empty(t, gsSet.ObjectMeta.Name)
 	assert.Equal(t, f.ObjectMeta.Namespace, gsSet.ObjectMeta.Namespace)
 	assert.Equal(t, f.ObjectMeta.Name+"-", gsSet.ObjectMeta.GenerateName)
 	assert.Equal(t, f.ObjectMeta.Name, gsSet.ObjectMeta.Labels[FleetNameLabel])
@@ -86,21 +86,21 @@ func TestFleetGameServerSetGameServer(t *testing.T) {
 			Key:   "Foo",
 			Order: "Ascending"}}
 	assert.NotNil(t, f.Spec.Priorities)
-	assert.Equal(t, f.Spec.Priorities[0], Priority{Type: "Counter", Key: "Foo", Order: "Ascending"})
+	assert.Equal(t, Priority{Type: "Counter", Key: "Foo", Order: "Ascending"}, f.Spec.Priorities[0])
 
 	gsSet = f.GameServerSet()
 	assert.NotNil(t, gsSet.Spec.AllocationOverflow)
 	assert.Equal(t, "things", gsSet.Spec.AllocationOverflow.Labels["stuff"])
 
-	assert.Equal(t, gsSet.Spec.Priorities[0], Priority{Type: "Counter", Key: "Foo", Order: "Ascending"})
+	assert.Equal(t, Priority{Type: "Counter", Key: "Foo", Order: "Ascending"}, gsSet.Spec.Priorities[0])
 }
 
 func TestFleetApplyDefaults(t *testing.T) {
 	f := &Fleet{}
 
 	// gate
-	assert.EqualValues(t, "", f.Spec.Strategy.Type)
-	assert.EqualValues(t, "", f.Spec.Scheduling)
+	assert.Empty(t, f.Spec.Strategy.Type)
+	assert.Empty(t, f.Spec.Scheduling)
 	assert.EqualValues(t, 0, f.Spec.Replicas)
 
 	f.ApplyDefaults()
@@ -154,7 +154,7 @@ func TestFleetGameserverSpec(t *testing.T) {
 	f := defaultFleet()
 	f.ApplyDefaults()
 	errs := f.Validate(fakeAPIHooks{})
-	assert.Len(t, errs, 0)
+	assert.Empty(t, errs)
 
 	f.Spec.Template.Spec.Template =
 		corev1.PodTemplateSpec{
@@ -174,7 +174,7 @@ func TestFleetGameserverSpec(t *testing.T) {
 
 	f.Spec.Template.Spec.Container = "container"
 	errs = f.Validate(fakeAPIHooks{})
-	assert.Len(t, errs, 0)
+	assert.Empty(t, errs)
 
 	// Verify RollingUpdate parameters validation
 	percent := intstr.FromString("0%")
@@ -259,7 +259,7 @@ func TestFleetName(t *testing.T) {
 	f.Name = ""
 	f.GenerateName = longName
 	errs = f.Validate(fakeAPIHooks{})
-	assert.Len(t, errs, 0)
+	assert.Empty(t, errs)
 }
 
 func TestSumStatusReplicas(t *testing.T) {

--- a/pkg/apis/agones/v1/gameserver.go
+++ b/pkg/apis/agones/v1/gameserver.go
@@ -164,6 +164,7 @@ const (
 	NodePodIP corev1.NodeAddressType = "PodIP"
 
 	// PassthroughPortAssignmentAnnotation is an annotation to keep track of game server container and its Passthrough ports indices
+	//nolint:gosec // G101: matches on the "Pass" in "Passthrough"; this is an annotation key, not a credential.
 	PassthroughPortAssignmentAnnotation = "agones.dev/container-passthrough-port-assignment"
 
 	// True is the string "true" to appease the goconst lint.

--- a/pkg/apis/agones/v1/gameserver_test.go
+++ b/pkg/apis/agones/v1/gameserver_test.go
@@ -1571,7 +1571,7 @@ func TestGameServerPodNoErrors(t *testing.T) {
 	fixture.ApplyDefaults()
 
 	pod, err := fixture.Pod(fakeAPIHooks{})
-	assert.Nil(t, err, "Pod should not return an error")
+	assert.NoError(t, err, "Pod should not return an error")
 	assert.Equal(t, fixture.ObjectMeta.Name, pod.ObjectMeta.Name)
 	assert.Equal(t, fixture.ObjectMeta.Name, pod.Spec.Hostname)
 	assert.Equal(t, fixture.ObjectMeta.Namespace, pod.ObjectMeta.Namespace)
@@ -1629,7 +1629,7 @@ func TestGameServerPodContainerNotFoundErrReturned(t *testing.T) {
 	}
 
 	_, err := fixture.Pod(fakeAPIHooks{})
-	if assert.NotNil(t, err, "Pod should return an error") {
+	if assert.Error(t, err, "Pod should return an error") {
 		assert.Equal(t, "failed to find container named Container1 in pod spec", err.Error())
 	}
 }
@@ -1646,7 +1646,7 @@ func TestGameServerPodWithSidecarNoErrors(t *testing.T) {
 	sidecar := corev1.Container{Name: "sidecar", Image: "container/sidecar"}
 	fixture.Spec.Template.Spec.ServiceAccountName = "other-agones-sdk"
 	pod, err := fixture.Pod(fakeAPIHooks{}, sidecar)
-	assert.Nil(t, err, "Pod should not return an error")
+	assert.NoError(t, err, "Pod should not return an error")
 	assert.Equal(t, fixture.ObjectMeta.Name, pod.ObjectMeta.Name)
 	assert.Len(t, pod.Spec.Containers, 2, "Should have two containers")
 	assert.Equal(t, "other-agones-sdk", pod.Spec.ServiceAccountName)
@@ -1667,7 +1667,7 @@ func TestGameServerPodWithInitSidecarNoErrors(t *testing.T) {
 	sidecar := corev1.Container{Name: "sidecar", Image: "container/sidecar"}
 	fixture.Spec.Template.Spec.ServiceAccountName = "other-agones-sdk"
 	pod, err := fixture.Pod(fakeAPIHooks{}, sidecar)
-	assert.Nil(t, err, "Pod should not return an error")
+	assert.NoError(t, err, "Pod should not return an error")
 	assert.Equal(t, fixture.ObjectMeta.Name, pod.ObjectMeta.Name)
 	assert.Len(t, pod.Spec.Containers, 1, "Should have one containers")
 	assert.Equal(t, "other-agones-sdk", pod.Spec.ServiceAccountName)
@@ -1675,7 +1675,7 @@ func TestGameServerPodWithInitSidecarNoErrors(t *testing.T) {
 	assert.Equal(t, corev1.ContainerRestartPolicyAlways, *pod.Spec.InitContainers[0].RestartPolicy)
 	assert.Equal(t, "container", pod.Spec.Containers[0].Name)
 	assert.True(t, metav1.IsControlledBy(pod, fixture))
-	assert.Equal(t, pod.Spec.RestartPolicy, corev1.RestartPolicyNever)
+	assert.Equal(t, corev1.RestartPolicyNever, pod.Spec.RestartPolicy)
 }
 
 func TestGameServerPodWithInitSidecarPrependsToExistingInitContainers(t *testing.T) {
@@ -1915,7 +1915,7 @@ func TestGameServerPatch(t *testing.T) {
 	delta.Spec.Container = "bear"
 
 	patch, err := fixture.Patch(delta)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Contains(t, string(patch), `{"op":"replace","path":"/spec/container","value":"bear"}`)
 	assert.Contains(t, string(patch), `{"op":"test","path":"/metadata/resourceVersion","value":"1234"}`)
@@ -1946,7 +1946,7 @@ func TestGameServerGetDevAddress(t *testing.T) {
 	regularGs.ObjectMeta.Annotations = map[string]string{}
 	devAddress, isDev = regularGs.GetDevAddress()
 	assert.False(t, isDev, "dev-game should NOT have a dev-address")
-	assert.Equal(t, "", devAddress, "dev-address IP address should be 127.1.1.1")
+	assert.Empty(t, devAddress, "dev-address IP address should be 127.1.1.1")
 }
 
 func TestGameServerIsDeletable(t *testing.T) {
@@ -2059,7 +2059,7 @@ func TestGameServerApplyToPodContainer(t *testing.T) {
 				return c
 			})
 
-			if tc.expected.err != "" && assert.NotNil(t, result) {
+			if tc.expected.err != "" && assert.Error(t, result) {
 				assert.Equal(t, tc.expected.err, result.Error())
 			}
 			assert.Equal(t, tc.expected.tty, pod.Spec.Containers[0].TTY)

--- a/pkg/apis/agones/v1/gameserverset_test.go
+++ b/pkg/apis/agones/v1/gameserverset_test.go
@@ -50,7 +50,7 @@ func TestGameServerSetGameServer(t *testing.T) {
 	}
 
 	gs := gsSet.GameServer()
-	assert.Equal(t, "", gs.ObjectMeta.Name)
+	assert.Empty(t, gs.ObjectMeta.Name)
 	assert.Equal(t, gsSet.ObjectMeta.Namespace, gs.ObjectMeta.Namespace)
 	assert.Equal(t, gsSet.ObjectMeta.Name+"-", gs.ObjectMeta.GenerateName)
 	assert.Equal(t, gsSet.ObjectMeta.Name, gs.ObjectMeta.Labels[GameServerSetGameServerLabel])
@@ -96,7 +96,7 @@ func TestGameServerSetValidateUpdate(t *testing.T) {
 	newGSS.Name = ""
 	newGSS.GenerateName = longName
 	errs = newGSS.Validate(fakeAPIHooks{})
-	assert.Len(t, errs, 0)
+	assert.Empty(t, errs)
 
 	newGSS = gsSet.DeepCopy()
 	newGSS.Name = longName

--- a/pkg/apis/allocation/v1/gameserverallocation_test.go
+++ b/pkg/apis/allocation/v1/gameserverallocation_test.go
@@ -154,7 +154,7 @@ func TestGameServerSelectorApplyDefaults(t *testing.T) {
 	assert.Equal(t, int64(10), s.Counters["foo"].MaxAvailable)
 	assert.Equal(t, int64(2), s.Lists["bar"].MinAvailable)
 	assert.Equal(t, int64(0), s.Lists["bar"].MaxAvailable)
-	assert.Equal(t, "", s.Lists["bar"].ContainsValue)
+	assert.Empty(t, s.Lists["bar"].ContainsValue)
 
 	// Test apply defaults is idempotent -- calling ApplyDefaults more than one time does not change the original result.
 	s.ApplyDefaults()
@@ -165,7 +165,7 @@ func TestGameServerSelectorApplyDefaults(t *testing.T) {
 	assert.Equal(t, int64(10), s.Counters["foo"].MaxAvailable)
 	assert.Equal(t, int64(2), s.Lists["bar"].MinAvailable)
 	assert.Equal(t, int64(0), s.Lists["bar"].MaxAvailable)
-	assert.Equal(t, "", s.Lists["bar"].ContainsValue)
+	assert.Empty(t, s.Lists["bar"].ContainsValue)
 }
 
 func TestGameServerSelectorValidate(t *testing.T) {
@@ -313,17 +313,17 @@ func TestMetaPatchValidate(t *testing.T) {
 	}
 	path := field.NewPath("spec", "metadata")
 	allErrs := mp.Validate(path)
-	assert.Len(t, allErrs, 0)
+	assert.Empty(t, allErrs)
 
 	mp.Labels = map[string]string{}
 	mp.Annotations = map[string]string{}
 	allErrs = mp.Validate(path)
-	assert.Len(t, allErrs, 0)
+	assert.Empty(t, allErrs)
 
 	mp.Labels["foo"] = "bar"
 	mp.Annotations["bar"] = "foo"
 	allErrs = mp.Validate(path)
-	assert.Len(t, allErrs, 0)
+	assert.Empty(t, allErrs)
 
 	// invalid label
 	invalid := mp.DeepCopy()
@@ -1174,7 +1174,7 @@ func TestGameServerAllocationValidate(t *testing.T) {
 	gsa.ApplyDefaults()
 
 	allErrs := gsa.Validate()
-	assert.Len(t, allErrs, 0)
+	assert.Empty(t, allErrs)
 
 	gsa.Spec.Scheduling = "FLERG"
 

--- a/pkg/apis/autoscaling/v1/fleetautoscaler_test.go
+++ b/pkg/apis/autoscaling/v1/fleetautoscaler_test.go
@@ -71,7 +71,7 @@ func TestFleetAutoscalerValidateUpdate(t *testing.T) {
 		fas.Spec.Policy.Buffer.BufferSize = intstr.FromString("20%")
 		causes := fas.Validate()
 
-		assert.Len(t, causes, 0)
+		assert.Empty(t, causes)
 	})
 
 	t.Run("bufferSize bad percent", func(t *testing.T) {
@@ -132,7 +132,7 @@ func TestFleetAutoscalerWebhookValidateUpdate(t *testing.T) {
 		fas := webhookFixture()
 		causes := fas.Validate()
 
-		assert.Len(t, causes, 0)
+		assert.Empty(t, causes)
 	})
 
 	t.Run("good url value", func(t *testing.T) {
@@ -142,7 +142,7 @@ func TestFleetAutoscalerWebhookValidateUpdate(t *testing.T) {
 		fas.Spec.Policy.Webhook.Service = nil
 		causes := fas.Validate()
 
-		assert.Len(t, causes, 0)
+		assert.Empty(t, causes)
 	})
 
 	t.Run("bad URL and service value", func(t *testing.T) {
@@ -176,7 +176,7 @@ func TestFleetAutoscalerWebhookValidateUpdate(t *testing.T) {
 		fas.Spec.Policy.Webhook.CABundle = []byte(goodCaBundle)
 
 		causes := fas.Validate()
-		assert.Len(t, causes, 0)
+		assert.Empty(t, causes)
 	})
 
 	t.Run("https url and invalid CABundle value", func(t *testing.T) {
@@ -199,7 +199,7 @@ func TestFleetAutoscalerWebhookValidateUpdate(t *testing.T) {
 		fas.Spec.Policy.Webhook.CABundle = nil
 
 		causes := fas.Validate()
-		assert.Len(t, causes, 0)
+		assert.Empty(t, causes)
 	})
 
 	t.Run("bad url value", func(t *testing.T) {

--- a/pkg/apis/multicluster/v1/gameserverallocationpolicy.go
+++ b/pkg/apis/multicluster/v1/gameserverallocationpolicy.go
@@ -174,6 +174,7 @@ func selectRandomWeighted(connections []*ClusterConnectionInfo, weights []int) *
 		return nil
 	}
 
+	//nolint:gosec // G404: weighted pick between allocation policies; nothing here is a secret.
 	randValue := rand.Intn(sum)
 	sum = 0
 	for i, weight := range weights {

--- a/pkg/apis/multicluster/v1/gameserverallocationpolicy_test.go
+++ b/pkg/apis/multicluster/v1/gameserverallocationpolicy_test.go
@@ -336,7 +336,7 @@ func TestConnectionInfoIterator_SameClustersAndPriorities(t *testing.T) {
 	res := iterator.priorityToCluster[444]["cluster-name"]
 
 	// check an internal slice of policies
-	if assert.Equal(t, 2, len(res)) {
+	if assert.Len(t, res, 2) {
 		assert.Equal(t, "cluster-name", res[0].Spec.ConnectionInfo.ClusterName)
 		assert.Equal(t, int32(444), res[0].Spec.Priority)
 		assert.Equal(t, "cluster-name", res[1].Spec.ConnectionInfo.ClusterName)

--- a/pkg/cloudproduct/generic/generic_test.go
+++ b/pkg/cloudproduct/generic/generic_test.go
@@ -71,7 +71,7 @@ func TestGameServerPodAutoscalerAnnotations(t *testing.T) {
 				}}
 			}
 			pod, err := gs.Pod(&generic{})
-			assert.Nil(t, err, "Pod should not return an error")
+			assert.NoError(t, err, "Pod should not return an error")
 			assert.Equal(t, gs.ObjectMeta.Name, pod.ObjectMeta.Name)
 			assert.Equal(t, gs.ObjectMeta.Namespace, pod.ObjectMeta.Namespace)
 			assert.Equal(t, agonesv1.GameServerLabelRole, pod.ObjectMeta.Labels[agonesv1.RoleLabel])

--- a/pkg/cloudproduct/gke/gke_test.go
+++ b/pkg/cloudproduct/gke/gke_test.go
@@ -65,7 +65,7 @@ func TestSyncPodPortsToGameServer(t *testing.T) {
 			oldPod := tc.pod.DeepCopy()
 			err := (&gkeAutopilot{}).SyncPodPortsToGameServer(tc.gs, tc.pod)
 			if tc.wantErr {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 				return
 			}
 			if assert.NoError(t, err) {

--- a/pkg/fleetautoscalers/controller.go
+++ b/pkg/fleetautoscalers/controller.go
@@ -250,7 +250,7 @@ func (ext *Extensions) mutationHandler(review admissionv1.AdmissionReview) (admi
 	if err != nil {
 		// If the JSON is invalid during mutation, fall through to validation. This allows OpenAPI schema validation
 		// to proceed, resulting in a more user friendly error message.
-		return review, nil
+		return review, nil //nolint:nilerr // deliberate: see comment above.
 	}
 
 	fas.ApplyDefaults()

--- a/pkg/fleetautoscalers/controller_test.go
+++ b/pkg/fleetautoscalers/controller_test.go
@@ -17,7 +17,6 @@ package fleetautoscalers
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -196,11 +195,11 @@ func TestControllerCreationValidationHandler(t *testing.T) {
 		defer cancel()
 
 		review, err := newAdmissionReview(*fas)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		result, err := ext.validationHandler(review)
-		assert.Nil(t, err)
-		assert.True(t, result.Response.Allowed, fmt.Sprintf("%#v", result.Response))
+		assert.NoError(t, err)
+		assert.True(t, result.Response.Allowed, "%#v", result.Response)
 	})
 
 	t.Run("invalid fleet autoscaler", func(t *testing.T) {
@@ -214,11 +213,11 @@ func TestControllerCreationValidationHandler(t *testing.T) {
 		defer cancel()
 
 		review, err := newAdmissionReview(*fas)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		result, err := ext.validationHandler(review)
-		assert.Nil(t, err)
-		assert.False(t, result.Response.Allowed, fmt.Sprintf("%#v", result.Response))
+		assert.NoError(t, err)
+		assert.False(t, result.Response.Allowed, "%#v", result.Response)
 		assert.Equal(t, metav1.StatusFailure, result.Response.Result.Status)
 		assert.Equal(t, metav1.StatusReasonInvalid, result.Response.Result.Reason)
 		assert.NotEmpty(t, result.Response.Result.Details)
@@ -228,11 +227,11 @@ func TestControllerCreationValidationHandler(t *testing.T) {
 		ext := newFakeExtensions()
 
 		review, err := newInvalidAdmissionReview()
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		_, err = ext.validationHandler(review)
 
-		if assert.NotNil(t, err) {
+		if assert.Error(t, err) {
 			assert.Equal(t, "error unmarshalling FleetAutoscaler json after schema validation: \"MQ==\": json: cannot unmarshal string into Go value of type v1.FleetAutoscaler", err.Error())
 		}
 	})
@@ -249,11 +248,11 @@ func TestWebhookControllerCreationValidationHandler(t *testing.T) {
 		defer cancel()
 
 		review, err := newAdmissionReview(*fas)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		result, err := ext.validationHandler(review)
-		assert.Nil(t, err)
-		assert.True(t, result.Response.Allowed, fmt.Sprintf("%#v", result.Response))
+		assert.NoError(t, err)
+		assert.True(t, result.Response.Allowed, "%#v", result.Response)
 	})
 
 	t.Run("invalid fleet autoscaler", func(t *testing.T) {
@@ -267,11 +266,11 @@ func TestWebhookControllerCreationValidationHandler(t *testing.T) {
 		defer cancel()
 
 		review, err := newAdmissionReview(*fas)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		result, err := ext.validationHandler(review)
-		assert.Nil(t, err)
-		assert.False(t, result.Response.Allowed, fmt.Sprintf("%#v", result.Response))
+		assert.NoError(t, err)
+		assert.False(t, result.Response.Allowed, "%#v", result.Response)
 		assert.Equal(t, metav1.StatusFailure, result.Response.Result.Status)
 		assert.Equal(t, metav1.StatusReasonInvalid, result.Response.Result.Reason)
 		assert.NotEmpty(t, result.Response.Result.Details)
@@ -318,7 +317,7 @@ func TestControllerSyncFleetAutoscaler(t *testing.T) {
 		fleetAutoscalerThreadEventually(t, c, fas)
 
 		err := c.syncFleetAutoscaler(ctx, "default/fas-1")
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		agtesting.AssertNoEvent(t, m.FakeRecorder.Events)
 	})
 
@@ -344,11 +343,11 @@ func TestControllerSyncFleetAutoscaler(t *testing.T) {
 			fasUpdated = true
 			ca := action.(k8stesting.UpdateAction)
 			fas := ca.GetObject().(*autoscalingv1.FleetAutoscaler)
-			assert.Equal(t, fas.Status.AbleToScale, true)
-			assert.Equal(t, fas.Status.ScalingLimited, false)
-			assert.Equal(t, fas.Status.CurrentReplicas, int32(5))
-			assert.Equal(t, fas.Status.DesiredReplicas, int32(12))
-			assert.Equal(t, fas.Status.LastAppliedPolicy, autoscalingv1.BufferPolicyType)
+			assert.True(t, fas.Status.AbleToScale)
+			assert.False(t, fas.Status.ScalingLimited)
+			assert.Equal(t, int32(5), fas.Status.CurrentReplicas)
+			assert.Equal(t, int32(12), fas.Status.DesiredReplicas)
+			assert.Equal(t, autoscalingv1.BufferPolicyType, fas.Status.LastAppliedPolicy)
 			assert.NotNil(t, fas.Status.LastScaleTime)
 			return true, fas, nil
 		})
@@ -361,7 +360,7 @@ func TestControllerSyncFleetAutoscaler(t *testing.T) {
 			fUpdated = true
 			ca := action.(k8stesting.UpdateAction)
 			f := ca.GetObject().(*agonesv1.Fleet)
-			assert.Equal(t, f.Spec.Replicas, int32(12))
+			assert.Equal(t, int32(12), f.Spec.Replicas)
 			return true, f, nil
 		})
 
@@ -370,7 +369,7 @@ func TestControllerSyncFleetAutoscaler(t *testing.T) {
 		fleetAutoscalerThreadEventually(t, c, fas)
 
 		err := c.syncFleetAutoscaler(ctx, "default/fas-1")
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.True(t, fUpdated, "fleet should have been updated")
 		assert.True(t, fasUpdated, "fleetautoscaler should have been updated")
 		agtesting.AssertEventContains(t, m.FakeRecorder.Events, "AutoScalingFleet")
@@ -404,11 +403,11 @@ func TestControllerSyncFleetAutoscaler(t *testing.T) {
 			fasUpdated = true
 			ca := action.(k8stesting.UpdateAction)
 			fas := ca.GetObject().(*autoscalingv1.FleetAutoscaler)
-			assert.Equal(t, fas.Status.AbleToScale, true)
-			assert.Equal(t, fas.Status.ScalingLimited, false)
-			assert.Equal(t, fas.Status.CurrentReplicas, int32(50))
-			assert.Equal(t, fas.Status.DesiredReplicas, int32(100))
-			assert.Equal(t, fas.Status.LastAppliedPolicy, autoscalingv1.WebhookPolicyType)
+			assert.True(t, fas.Status.AbleToScale)
+			assert.False(t, fas.Status.ScalingLimited)
+			assert.Equal(t, int32(50), fas.Status.CurrentReplicas)
+			assert.Equal(t, int32(100), fas.Status.DesiredReplicas)
+			assert.Equal(t, autoscalingv1.WebhookPolicyType, fas.Status.LastAppliedPolicy)
 			assert.NotNil(t, fas.Status.LastScaleTime)
 			return true, fas, nil
 		})
@@ -421,7 +420,7 @@ func TestControllerSyncFleetAutoscaler(t *testing.T) {
 			fUpdated = true
 			ca := action.(k8stesting.UpdateAction)
 			f := ca.GetObject().(*agonesv1.Fleet)
-			assert.Equal(t, f.Spec.Replicas, int32(100))
+			assert.Equal(t, int32(100), f.Spec.Replicas)
 			return true, f, nil
 		})
 
@@ -430,7 +429,7 @@ func TestControllerSyncFleetAutoscaler(t *testing.T) {
 		fleetAutoscalerThreadEventually(t, c, fas)
 
 		err := c.syncFleetAutoscaler(ctx, "default/fas-1")
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.True(t, fUpdated, "fleet should have been updated")
 		assert.True(t, fasUpdated, "fleetautoscaler should have been updated")
 		agtesting.AssertEventContains(t, m.FakeRecorder.Events, "AutoScalingFleet")
@@ -479,7 +478,7 @@ func TestControllerSyncFleetAutoscaler(t *testing.T) {
 		fleetAutoscalerThreadEventually(t, c, fas)
 
 		err := c.syncFleetAutoscaler(ctx, "default/fas-1")
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		agtesting.AssertNoEvent(t, m.FakeRecorder.Events)
 	})
 
@@ -505,11 +504,11 @@ func TestControllerSyncFleetAutoscaler(t *testing.T) {
 			fasUpdated = true
 			ca := action.(k8stesting.UpdateAction)
 			fas := ca.GetObject().(*autoscalingv1.FleetAutoscaler)
-			assert.Equal(t, fas.Status.AbleToScale, true)
-			assert.Equal(t, fas.Status.ScalingLimited, false)
-			assert.Equal(t, fas.Status.CurrentReplicas, int32(20))
-			assert.Equal(t, fas.Status.DesiredReplicas, int32(13))
-			assert.Equal(t, fas.Status.LastAppliedPolicy, autoscalingv1.BufferPolicyType)
+			assert.True(t, fas.Status.AbleToScale)
+			assert.False(t, fas.Status.ScalingLimited)
+			assert.Equal(t, int32(20), fas.Status.CurrentReplicas)
+			assert.Equal(t, int32(13), fas.Status.DesiredReplicas)
+			assert.Equal(t, autoscalingv1.BufferPolicyType, fas.Status.LastAppliedPolicy)
 			assert.NotNil(t, fas.Status.LastScaleTime)
 			return true, fas, nil
 		})
@@ -522,7 +521,7 @@ func TestControllerSyncFleetAutoscaler(t *testing.T) {
 			fUpdated = true
 			ca := action.(k8stesting.UpdateAction)
 			f := ca.GetObject().(*agonesv1.Fleet)
-			assert.Equal(t, f.Spec.Replicas, int32(13))
+			assert.Equal(t, int32(13), f.Spec.Replicas)
 
 			return true, f, nil
 		})
@@ -532,7 +531,7 @@ func TestControllerSyncFleetAutoscaler(t *testing.T) {
 		fleetAutoscalerThreadEventually(t, c, fas)
 
 		err := c.syncFleetAutoscaler(ctx, "default/fas-1")
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.True(t, fUpdated, "fleet should have been updated")
 		assert.True(t, fasUpdated, "fleetautoscaler should have been updated")
 		agtesting.AssertEventContains(t, m.FakeRecorder.Events, "AutoScalingFleet")
@@ -577,7 +576,7 @@ func TestControllerSyncFleetAutoscaler(t *testing.T) {
 		fleetAutoscalerThreadEventually(t, c, fas)
 
 		err := c.syncFleetAutoscaler(ctx, "default/fas-1")
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		agtesting.AssertNoEvent(t, m.FakeRecorder.Events)
 	})
 
@@ -612,7 +611,7 @@ func TestControllerSyncFleetAutoscaler(t *testing.T) {
 		fleetAutoscalerThreadEventually(t, c, fas)
 
 		err := c.syncFleetAutoscaler(ctx, fas.ObjectMeta.Name)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		agtesting.AssertNoEvent(t, m.FakeRecorder.Events)
 	})
 
@@ -632,8 +631,8 @@ func TestControllerSyncFleetAutoscaler(t *testing.T) {
 			updated = true
 			ca := action.(k8stesting.UpdateAction)
 			fas := ca.GetObject().(*autoscalingv1.FleetAutoscaler)
-			assert.Equal(t, fas.Status.CurrentReplicas, int32(0))
-			assert.Equal(t, fas.Status.DesiredReplicas, int32(0))
+			assert.Equal(t, int32(0), fas.Status.CurrentReplicas)
+			assert.Equal(t, int32(0), fas.Status.DesiredReplicas)
 			return true, fas, nil
 		})
 
@@ -642,7 +641,7 @@ func TestControllerSyncFleetAutoscaler(t *testing.T) {
 		fleetAutoscalerThreadEventually(t, c, fas)
 
 		err := c.syncFleetAutoscaler(ctx, "default/fas-1")
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.True(t, updated)
 
 		agtesting.AssertEventContains(t, m.FakeRecorder.Events, "FailedGetFleet")
@@ -670,7 +669,7 @@ func TestControllerSyncFleetAutoscaler(t *testing.T) {
 		fleetAutoscalerThreadEventually(t, c, fas)
 
 		err := c.syncFleetAutoscaler(ctx, "default/fas-1")
-		if assert.NotNil(t, err) {
+		if assert.Error(t, err) {
 			assert.Equal(t, "error updating status for fleetautoscaler fas-1: random-err", err.Error())
 		}
 
@@ -700,7 +699,7 @@ func TestControllerSyncFleetAutoscaler(t *testing.T) {
 		fleetAutoscalerThreadEventually(t, c, fas)
 
 		err := c.syncFleetAutoscaler(ctx, "default/fas-1")
-		if assert.NotNil(t, err) {
+		if assert.Error(t, err) {
 			assert.Equal(t, "error calculating autoscaling fleet: fleet-1: wrong policy type, should be one of: Buffer, Webhook, Counter, List, Schedule, Chain", err.Error())
 		}
 	})
@@ -734,7 +733,7 @@ func TestControllerSyncFleetAutoscaler(t *testing.T) {
 		fleetAutoscalerThreadEventually(t, c, fas)
 
 		err := c.syncFleetAutoscaler(ctx, "default/fas-1")
-		if assert.NotNil(t, err) {
+		if assert.Error(t, err) {
 			assert.Equal(t, "error updating status for fleetautoscaler fas-1: random-err", err.Error())
 		}
 	})
@@ -762,7 +761,7 @@ func TestControllerSyncFleetAutoscaler(t *testing.T) {
 		fleetAutoscalerThreadEventually(t, c, fas)
 
 		err := c.syncFleetAutoscaler(ctx, "default/fas-1")
-		if assert.NotNil(t, err) {
+		if assert.Error(t, err) {
 			assert.Equal(t, "error autoscaling fleet fleet-1 to 7 replicas: error updating replicas for fleet fleet-1: random-err", err.Error())
 		}
 
@@ -817,7 +816,7 @@ func TestControllerScaleFleet(t *testing.T) {
 		})
 
 		err := c.scaleFleet(context.Background(), fas, f, replicas)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.True(t, update, "Fleet should be updated")
 		agtesting.AssertEventContains(t, m.FakeRecorder.Events, "ScalingFleet")
 	})
@@ -833,7 +832,7 @@ func TestControllerScaleFleet(t *testing.T) {
 		})
 
 		err := c.scaleFleet(context.Background(), fas, f, replicas)
-		if assert.NotNil(t, err) {
+		if assert.Error(t, err) {
 			assert.Equal(t, "error updating replicas for fleet fleet-1: random-err", err.Error())
 		}
 		agtesting.AssertEventContains(t, m.FakeRecorder.Events, "AutoScalingFleetError")
@@ -850,7 +849,7 @@ func TestControllerScaleFleet(t *testing.T) {
 		})
 
 		err := c.scaleFleet(context.Background(), fas, f, replicas)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		agtesting.AssertNoEvent(t, m.FakeRecorder.Events)
 	})
 }
@@ -868,11 +867,11 @@ func TestControllerUpdateStatus(t *testing.T) {
 			fasUpdated = true
 			ca := action.(k8stesting.UpdateAction)
 			fas := ca.GetObject().(*autoscalingv1.FleetAutoscaler)
-			assert.Equal(t, fas.Status.AbleToScale, true)
-			assert.Equal(t, fas.Status.ScalingLimited, false)
-			assert.Equal(t, fas.Status.CurrentReplicas, int32(10))
-			assert.Equal(t, fas.Status.DesiredReplicas, int32(20))
-			assert.Equal(t, fas.Status.LastAppliedPolicy, autoscalingv1.BufferPolicyType)
+			assert.True(t, fas.Status.AbleToScale)
+			assert.False(t, fas.Status.ScalingLimited)
+			assert.Equal(t, int32(10), fas.Status.CurrentReplicas)
+			assert.Equal(t, int32(20), fas.Status.DesiredReplicas)
+			assert.Equal(t, autoscalingv1.BufferPolicyType, fas.Status.LastAppliedPolicy)
 			assert.NotNil(t, fas.Status.LastScaleTime)
 			return true, fas, nil
 		})
@@ -881,7 +880,7 @@ func TestControllerUpdateStatus(t *testing.T) {
 		defer cancel()
 
 		err := c.updateStatus(ctx, fas, 10, 20, true, false, fas.Spec.Policy.Type)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.True(t, fasUpdated)
 		agtesting.AssertNoEvent(t, m.FakeRecorder.Events)
 	})
@@ -906,7 +905,7 @@ func TestControllerUpdateStatus(t *testing.T) {
 		defer cancel()
 
 		err := c.updateStatus(ctx, fas, fas.Status.CurrentReplicas, fas.Status.DesiredReplicas, false, fas.Status.ScalingLimited, fas.Spec.Policy.Type)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		agtesting.AssertNoEvent(t, m.FakeRecorder.Events)
 	})
 
@@ -922,7 +921,7 @@ func TestControllerUpdateStatus(t *testing.T) {
 		defer cancel()
 
 		err := c.updateStatus(ctx, fas, fas.Status.CurrentReplicas, fas.Status.DesiredReplicas, false, fas.Status.ScalingLimited, fas.Spec.Policy.Type)
-		if assert.NotNil(t, err) {
+		if assert.Error(t, err) {
 			assert.Equal(t, "error updating status for fleetautoscaler fas-1: random-err", err.Error())
 		}
 		agtesting.AssertNoEvent(t, m.FakeRecorder.Events)
@@ -933,7 +932,7 @@ func TestControllerUpdateStatus(t *testing.T) {
 		fas, _ := defaultFixtures()
 
 		err := c.updateStatus(context.Background(), fas, 10, 20, true, true, fas.Spec.Policy.Type)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		agtesting.AssertEventContains(t, m.FakeRecorder.Events, "ScalingLimited")
 	})
 
@@ -942,7 +941,7 @@ func TestControllerUpdateStatus(t *testing.T) {
 		fas, _ := defaultFixtures()
 
 		err := c.updateStatus(context.Background(), fas, 1, 3, true, true, fas.Spec.Policy.Type)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		agtesting.AssertEventContains(t, m.FakeRecorder.Events, "limited to minimum size of 3")
 	})
 
@@ -951,7 +950,7 @@ func TestControllerUpdateStatus(t *testing.T) {
 		fas, _ := defaultFixtures()
 
 		err := c.updateStatus(context.Background(), fas, 12, 10, true, true, fas.Spec.Policy.Type)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		agtesting.AssertEventContains(t, m.FakeRecorder.Events, "limited to maximum size of 10")
 	})
 }
@@ -970,10 +969,10 @@ func TestControllerUpdateStatusUnableToScale(t *testing.T) {
 			fasUpdated = true
 			ca := action.(k8stesting.UpdateAction)
 			fas := ca.GetObject().(*autoscalingv1.FleetAutoscaler)
-			assert.Equal(t, fas.Status.AbleToScale, false)
-			assert.Equal(t, fas.Status.ScalingLimited, false)
-			assert.Equal(t, fas.Status.CurrentReplicas, int32(0))
-			assert.Equal(t, fas.Status.DesiredReplicas, int32(0))
+			assert.False(t, fas.Status.AbleToScale)
+			assert.False(t, fas.Status.ScalingLimited)
+			assert.Equal(t, int32(0), fas.Status.CurrentReplicas)
+			assert.Equal(t, int32(0), fas.Status.DesiredReplicas)
 			assert.Equal(t, fas.Status.LastAppliedPolicy, autoscalingv1.FleetAutoscalerPolicyType(""))
 			assert.Nil(t, fas.Status.LastScaleTime)
 			return true, fas, nil
@@ -983,7 +982,7 @@ func TestControllerUpdateStatusUnableToScale(t *testing.T) {
 		defer cancel()
 
 		err := c.updateStatusUnableToScale(ctx, fas)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.True(t, fasUpdated)
 		agtesting.AssertNoEvent(t, m.FakeRecorder.Events)
 	})
@@ -1003,7 +1002,7 @@ func TestControllerUpdateStatusUnableToScale(t *testing.T) {
 		defer cancel()
 
 		err := c.updateStatusUnableToScale(ctx, fas)
-		if assert.NotNil(t, err) {
+		if assert.Error(t, err) {
 			assert.Equal(t, "error updating status for fleetautoscaler fas-1: random-err", err.Error())
 		}
 		agtesting.AssertNoEvent(t, m.FakeRecorder.Events)
@@ -1027,7 +1026,7 @@ func TestControllerUpdateStatusUnableToScale(t *testing.T) {
 		defer cancel()
 
 		err := c.updateStatusUnableToScale(ctx, fas)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		agtesting.AssertNoEvent(t, m.FakeRecorder.Events)
 	})
 }
@@ -1091,7 +1090,7 @@ func TestControllerAddUpdateDeleteFasThread(t *testing.T) {
 	ctx, cancel := agtesting.StartInformers(m, c.fleetAutoscalerSynced)
 	defer cancel()
 	go func() {
-		require.NoError(t, c.Run(ctx, 1))
+		assert.NoError(t, c.Run(ctx, 1))
 	}()
 
 	fas, _ := defaultFixtures()
@@ -1148,7 +1147,7 @@ func TestControllerAddUpdateDeleteFasThread(t *testing.T) {
 
 	c.deleteFasThread(ctx, fas2, true)
 	c.fasThreadMutex.Lock()
-	require.Len(t, c.fasThreads, 0)
+	require.Empty(t, c.fasThreads)
 	c.fasThreadMutex.Unlock()
 
 	// we shouldn't get any more updates, so wait for 3 checks in a row that have the

--- a/pkg/fleetautoscalers/fleetautoscalers.go
+++ b/pkg/fleetautoscalers/fleetautoscalers.go
@@ -70,7 +70,7 @@ func computeDesiredFleetSize(ctx context.Context, state *fasState, pol autoscali
 	case autoscalingv1.BufferPolicyType:
 		replicas, limited, err = applyBufferPolicy(state, pol.Buffer, f, fasLog)
 	case autoscalingv1.WebhookPolicyType:
-		replicas, limited, err = applyWebhookPolicy(state, pol.Webhook, f, fasLog)
+		replicas, limited, err = applyWebhookPolicy(ctx, state, pol.Webhook, f, fasLog)
 	case autoscalingv1.CounterPolicyType:
 		replicas, limited, err = applyCounterOrListPolicyWrapper(state, pol.Counter, nil, f, gameServerNamespacedLister, nodeCounts, fasLog)
 	case autoscalingv1.ListPolicyType:
@@ -118,7 +118,12 @@ func applyWasmPolicy(ctx context.Context, state *fasState, wp *autoscalingv1.Was
 			return 0, false, errors.New("http client not set")
 		}
 
-		res, err := state.httpClient.Get(u.String())
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+		if err != nil {
+			return 0, false, errors.Wrapf(err, "failed to build request for Wasm module at %s", u.String())
+		}
+
+		res, err := state.httpClient.Do(req)
 		if err != nil {
 			return 0, false, errors.Wrapf(err, "failed to fetch Wasm module from %s", u.String())
 		}
@@ -276,7 +281,7 @@ func setCABundle(tlsConfig *tls.Config, caBundle []byte) error {
 	return nil
 }
 
-func applyWebhookPolicy(state *fasState, w *autoscalingv1.URLConfiguration, f *agonesv1.Fleet, fasLog *FasLogger) (replicas int32, limited bool, err error) {
+func applyWebhookPolicy(ctx context.Context, state *fasState, w *autoscalingv1.URLConfiguration, f *agonesv1.Fleet, fasLog *FasLogger) (replicas int32, limited bool, err error) {
 	if w == nil {
 		return 0, false, errors.New("webhookPolicy parameter must not be nil")
 	}
@@ -313,11 +318,13 @@ func applyWebhookPolicy(state *fasState, w *autoscalingv1.URLConfiguration, f *a
 		return 0, false, err
 	}
 
-	res, err := state.httpClient.Post(
-		u.String(),
-		"application/json",
-		strings.NewReader(string(b)),
-	)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), strings.NewReader(string(b)))
+	if err != nil {
+		return 0, false, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := state.httpClient.Do(req)
 	if err != nil {
 		return 0, false, err
 	}
@@ -592,7 +599,7 @@ func applyChainPolicy(ctx context.Context, state *fasState, c autoscalingv1.Chai
 					"Failed to apply SchedulePolicy ID=%s in ChainPolicy: %v", entry.ID, err)
 			}
 		case autoscalingv1.WebhookPolicyType:
-			replicas, limited, err = applyWebhookPolicy(state, entry.Webhook, f, fasLog)
+			replicas, limited, err = applyWebhookPolicy(ctx, state, entry.Webhook, f, fasLog)
 
 			if err != nil {
 				loggerForFleetAutoscalerKey(fasLog.fas.ObjectMeta.Name, fasLog.baseLogger).Debugf(

--- a/pkg/fleetautoscalers/fleetautoscalers_test.go
+++ b/pkg/fleetautoscalers/fleetautoscalers_test.go
@@ -223,10 +223,10 @@ func TestComputeDesiredFleetSize(t *testing.T) {
 
 			replicas, limited, err := computeDesiredFleetSize(ctx, &fasState{}, fas.Spec.Policy, f, gameServers.Lister().GameServers(f.ObjectMeta.Namespace), nc, &fasLog)
 
-			if tc.expected.err != "" && assert.NotNil(t, err) {
+			if tc.expected.err != "" && assert.Error(t, err) {
 				assert.Equal(t, tc.expected.err, err.Error())
 			} else {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				assert.Equal(t, tc.expected.replicas, replicas)
 				assert.Equal(t, tc.expected.limited, limited)
 			}
@@ -373,10 +373,10 @@ func TestApplyBufferPolicy(t *testing.T) {
 			}
 			replicas, limited, err := applyBufferPolicy(&fasState{}, tc.buffer, f, &fasLog)
 
-			if tc.expected.err != "" && assert.NotNil(t, err) {
+			if tc.expected.err != "" && assert.Error(t, err) {
 				assert.Equal(t, tc.expected.err, err.Error())
 			} else {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				assert.Equal(t, tc.expected.replicas, replicas)
 				assert.Equal(t, tc.expected.limited, limited)
 			}
@@ -630,14 +630,14 @@ func TestApplyWebhookPolicy(t *testing.T) {
 				recorder:       m.FakeRecorder,
 				currChainEntry: &fas.Status.LastAppliedPolicy,
 			}
-			replicas, limited, err := applyWebhookPolicy(&fasState{}, tc.webhookPolicy, f, &fasLog)
+			replicas, limited, err := applyWebhookPolicy(context.Background(), &fasState{}, tc.webhookPolicy, f, &fasLog)
 
-			if tc.expected.err != "" && assert.NotNil(t, err) {
+			if tc.expected.err != "" && assert.Error(t, err) {
 				assert.Equal(t, tc.expected.err, err.Error())
 			} else {
 				assert.Equal(t, tc.expected.replicas, replicas)
 				assert.Equal(t, tc.expected.limited, limited)
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 			}
 		})
 	}
@@ -673,9 +673,9 @@ func TestApplyWebhookPolicyWithMetadata(t *testing.T) {
 		recorder:       m.FakeRecorder,
 		currChainEntry: &fas.Status.LastAppliedPolicy,
 	}
-	replicas, limited, err := applyWebhookPolicy(&fasState{}, webhookPolicy, fleet, &fasLog)
+	replicas, limited, err := applyWebhookPolicy(context.Background(), &fasState{}, webhookPolicy, fleet, &fasLog)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.False(t, limited)
 	assert.Equal(t, fixedReplicas, replicas)
 }
@@ -700,9 +700,9 @@ func TestApplyWebhookPolicyNilFleet(t *testing.T) {
 		recorder:       m.FakeRecorder,
 		currChainEntry: &fas.Status.LastAppliedPolicy,
 	}
-	replicas, limited, err := applyWebhookPolicy(&fasState{}, w, nil, &fasLog)
+	replicas, limited, err := applyWebhookPolicy(context.Background(), &fasState{}, w, nil, &fasLog)
 
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Equal(t, "fleet parameter must not be nil", err.Error())
 	}
 
@@ -943,10 +943,10 @@ func TestBuildURLFromConfiguration(t *testing.T) {
 			url, err := buildURLFromConfiguration(tc.state, tc.config)
 
 			if tc.expected.err != "" {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tc.expected.err)
 			} else {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				assert.NotNil(t, url)
 				assert.Equal(t, tc.expected.url, url.String())
 
@@ -1730,9 +1730,9 @@ func TestApplyCounterPolicy(t *testing.T) {
 			replicas, limited, err := applyCounterOrListPolicy(tc.cp, nil, tc.fleet, informer.GameServers().Lister().GameServers(tc.fleet.ObjectMeta.Namespace), nc)
 
 			if tc.want.wantErr {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 			} else {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				assert.Equal(t, tc.want.replicas, replicas)
 				assert.Equal(t, tc.want.limited, limited)
 			}
@@ -2454,9 +2454,9 @@ func TestApplyListPolicy(t *testing.T) {
 			replicas, limited, err := applyCounterOrListPolicy(nil, tc.lp, tc.fleet, informer.GameServers().Lister().GameServers(tc.fleet.ObjectMeta.Namespace), nc)
 
 			if tc.want.wantErr {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 			} else {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				assert.Equal(t, tc.want.replicas, replicas)
 				assert.Equal(t, tc.want.limited, limited)
 			}
@@ -2826,9 +2826,9 @@ func TestApplySchedulePolicy(t *testing.T) {
 			replicas, limited, err := applySchedulePolicy(ctx, &fasState{}, tc.sp, f, nil, nil, tc.now, &fasLog)
 
 			if tc.want.wantErr {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 			} else {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				assert.Equal(t, tc.want.replicas, replicas)
 				assert.Equal(t, tc.want.limited, limited)
 			}
@@ -3017,9 +3017,9 @@ func TestApplyChainPolicy(t *testing.T) {
 			replicas, limited, err := applyChainPolicy(ctx, &fasState{}, *tc.cp, f, nil, nil, tc.now, &fasLog)
 
 			if tc.want.wantErr {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 			} else {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				assert.Equal(t, tc.want.replicas, replicas)
 				assert.Equal(t, tc.want.limited, limited)
 			}

--- a/pkg/fleets/controller.go
+++ b/pkg/fleets/controller.go
@@ -187,7 +187,7 @@ func (ext *Extensions) creationMutationHandler(review admissionv1.AdmissionRevie
 	if err != nil {
 		// If the JSON is invalid during mutation, fall through to validation. This allows OpenAPI schema validation
 		// to proceed, resulting in a more user friendly error message.
-		return review, nil
+		return review, nil //nolint:nilerr // deliberate: see comment above.
 	}
 
 	// This is the main logic of this function

--- a/pkg/fleets/controller_rollingupdatefix.go
+++ b/pkg/fleets/controller_rollingupdatefix.go
@@ -72,7 +72,6 @@ func (c *Controller) rollingUpdateRestFixedOnReadyRollingUpdateFix(ctx context.C
 
 	totalAlreadyScaledDown := int32(0)
 
-	totalScaleDownCount := int32(0)
 	// Check if we can scale down.
 	allGSS := rest
 	allGSS = append(allGSS, active)
@@ -99,10 +98,10 @@ func (c *Controller) rollingUpdateRestFixedOnReadyRollingUpdateFix(ctx context.C
 		// There could be the case when GameServerSet would be updated from another place, say Status or Spec would be updated
 		// We don't want to propagate such errors further
 		// And this set in sync with reconcileOldReplicaSets() Kubernetes code
-		return nil
+		return nil //nolint:nilerr // deliberate: see comment above.
 	}
 	// Resulting value is readyReplicasCount + unavailable - fleet.Spec.Replicas
-	totalScaleDownCount = readyReplicasCount - minAvailable
+	totalScaleDownCount := readyReplicasCount - minAvailable
 	if readyReplicasCount <= minAvailable {
 		// Cannot scale down.
 		return nil

--- a/pkg/fleets/controller_test.go
+++ b/pkg/fleets/controller_test.go
@@ -79,7 +79,7 @@ func TestControllerSyncFleet(t *testing.T) {
 		defer cancel()
 
 		err := c.syncFleet(ctx, "default/fleet-1")
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.True(t, created, "gameserverset should have been created")
 		agtesting.AssertEventContains(t, m.FakeRecorder.Events, "CreatingGameServerSet")
 	})
@@ -117,7 +117,7 @@ func TestControllerSyncFleet(t *testing.T) {
 		defer cancel()
 
 		err := c.syncFleet(ctx, "default/fleet-1")
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		agtesting.AssertNoEvent(t, m.FakeRecorder.Events)
 	})
 
@@ -154,7 +154,7 @@ func TestControllerSyncFleet(t *testing.T) {
 		defer cancel()
 
 		err := c.syncFleet(ctx, "default/fleet-1")
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.True(t, updated, "gameserverset should have been updated")
 		agtesting.AssertEventContains(t, m.FakeRecorder.Events, "ScalingGameServerSet")
 	})
@@ -199,7 +199,7 @@ func TestControllerSyncFleet(t *testing.T) {
 		defer cancel()
 
 		err := c.syncFleet(ctx, "default/fleet-1")
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		agtesting.AssertNoEvent(t, m.FakeRecorder.Events)
 	})
 
@@ -230,7 +230,7 @@ func TestControllerSyncFleet(t *testing.T) {
 		c.allocs.inc("default", "fleet-1", 1)
 
 		err := c.syncFleet(ctx, "default/fleet-1")
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, int64(1), f.Status.Allocations)
 	})
 
@@ -262,7 +262,7 @@ func TestControllerSyncFleet(t *testing.T) {
 		c, _ := newFakeController()
 
 		err := c.syncFleet(context.Background(), "default/fleet-1")
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	})
 
 	t.Run("fleet invalid strategy type", func(t *testing.T) {
@@ -460,7 +460,7 @@ func TestControllerRun(t *testing.T) {
 
 	go func() {
 		err := c.Run(ctx, 1)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	}()
 
 	f := func() string {
@@ -543,7 +543,7 @@ func TestControllerUpdateFleetStatus(t *testing.T) {
 		defer cancel()
 
 		err := c.updateFleetStatus(ctx, fleet)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.True(t, updated)
 	})
 
@@ -616,7 +616,7 @@ func TestControllerUpdateFleetPlayerStatus(t *testing.T) {
 	defer cancel()
 
 	err := c.updateFleetStatus(ctx, fleet)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, updated)
 }
 
@@ -706,7 +706,7 @@ func TestControllerUpdateFleetCounterStatus(t *testing.T) {
 	defer cancel()
 
 	err := c.updateFleetStatus(ctx, fleet)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, updated)
 }
 
@@ -796,7 +796,7 @@ func TestControllerUpdateFleetListStatus(t *testing.T) {
 	defer cancel()
 
 	err := c.updateFleetStatus(ctx, fleet)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, updated)
 }
 
@@ -1070,7 +1070,7 @@ func TestControllerUpsertGameServerSet(t *testing.T) {
 		})
 
 		err := c.upsertGameServerSet(context.Background(), f, gsSet, replicas)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		assert.True(t, created, "Should be created")
 		agtesting.AssertEventContains(t, m.FakeRecorder.Events, "CreatingGameServerSet")
@@ -1093,7 +1093,7 @@ func TestControllerUpsertGameServerSet(t *testing.T) {
 		})
 
 		err := c.upsertGameServerSet(context.Background(), f, gsSet, replicas)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		assert.True(t, update, "Should be updated")
 		agtesting.AssertEventContains(t, m.FakeRecorder.Events, "ScalingGameServerSet")
@@ -1145,7 +1145,7 @@ func TestControllerUpsertGameServerSet(t *testing.T) {
 		})
 
 		err := c.upsertGameServerSet(context.Background(), f, gsSet, replicas)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		agtesting.AssertNoEvent(t, m.FakeRecorder.Events)
 	})
 
@@ -1177,7 +1177,7 @@ func TestControllerUpsertGameServerSet(t *testing.T) {
 
 		// Update Priorities on the GameServerSet to match the Fleet
 		err := c.upsertGameServerSet(context.Background(), f, gsSet, gsSet.Spec.Replicas)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		assert.True(t, update, "Should be updated")
 		agtesting.AssertEventContains(t, m.FakeRecorder.Events, "UpdatingGameServerSet")
@@ -1238,7 +1238,7 @@ func TestControllerDeleteEmptyGameServerSets(t *testing.T) {
 	})
 
 	err := c.deleteEmptyGameServerSets(context.Background(), f, []*agonesv1.GameServerSet{gsSet1, gsSet2})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, deleted, "delete should happen")
 }
 
@@ -1255,7 +1255,7 @@ func TestControllerRollingUpdateDeploymentNoInactiveGSSNoErrors(t *testing.T) {
 	c, _ := newFakeController()
 
 	replicas, err := c.rollingUpdateDeployment(context.Background(), f, active, []*agonesv1.GameServerSet{})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, int32(25), replicas)
 }
 

--- a/pkg/gameserverallocations/allocation_cache_test.go
+++ b/pkg/gameserverallocations/allocation_cache_test.go
@@ -177,10 +177,10 @@ func TestAllocationCacheListSortedGameServers(t *testing.T) {
 
 			// This call initializes the cache
 			err := cache.syncCache()
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			err = cache.counter.Run(ctx, 0)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			list := cache.ListSortedGameServers(v.gsa)
 
@@ -471,10 +471,10 @@ func TestListSortedGameServersPriorities(t *testing.T) {
 
 			// This call initializes the cache
 			err := cache.syncCache()
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			err = cache.counter.Run(ctx, 0)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			got := cache.ListSortedGameServersPriorities(testScenario.gsa)
 
@@ -505,12 +505,12 @@ func TestAllocatorRunCacheSync(t *testing.T) {
 			return count == expected, nil
 		})
 
-		assert.NoError(t, err, fmt.Sprintf("Should be %d values", expected))
+		assert.NoError(t, err, "Should be %d values", expected)
 	}
 
 	go func() {
 		err := cache.Run(ctx)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	}()
 
 	gs := agonesv1.GameServer{

--- a/pkg/gameserverallocations/allocator.go
+++ b/pkg/gameserverallocations/allocator.go
@@ -270,15 +270,15 @@ func (c *Allocator) allocateFromLocalCluster(ctx context.Context, gsa *allocatio
 		return err
 	})
 
-	if err != nil && err != ErrNoGameServer && err != ErrConflictInGameServerSelection {
+	if err != nil && !goErrors.Is(err, ErrNoGameServer) && !goErrors.Is(err, ErrConflictInGameServerSelection) {
 		c.allocationCache.Resync()
 		return nil, err
 	}
 
-	switch err {
-	case ErrNoGameServer, ErrGameServerUpdateConflict:
+	switch {
+	case goErrors.Is(err, ErrNoGameServer), goErrors.Is(err, ErrGameServerUpdateConflict):
 		gsa.Status.State = allocationv1.GameServerAllocationUnAllocated
-	case ErrConflictInGameServerSelection:
+	case goErrors.Is(err, ErrConflictInGameServerSelection):
 		gsa.Status.State = allocationv1.GameServerAllocationContention
 	default:
 		gsa.ObjectMeta.Name = gs.ObjectMeta.Name

--- a/pkg/gameserverallocations/allocator_test.go
+++ b/pkg/gameserverallocations/allocator_test.go
@@ -93,7 +93,7 @@ func TestAllocatorAllocate(t *testing.T) {
 		}}
 	gsa.ApplyDefaults()
 	errs := gsa.Validate()
-	require.Len(t, errs, 0)
+	require.Empty(t, errs)
 
 	gs, err := a.allocate(ctx, &gsa)
 	require.NoError(t, err)
@@ -175,7 +175,7 @@ func TestAllocatorAllocatePriority(t *testing.T) {
 			}}
 		gsa.ApplyDefaults()
 		errs := gsa.Validate()
-		require.Len(t, errs, 0)
+		require.Empty(t, errs)
 
 		t.Run(name, func(t *testing.T) {
 			test(t, a, gsa.DeepCopy())
@@ -479,7 +479,7 @@ func TestAllocatorAllocateOnGameServerUpdateError(t *testing.T) {
 	// wait for all the gameservers to be in the cache
 	require.Eventuallyf(t, func() bool {
 		return a.allocationCache.cache.Len() == gsLen
-	}, 10*time.Second, time.Second, fmt.Sprintf("should be %d items in the cache", gsLen))
+	}, 10*time.Second, time.Second, "should be %d items in the cache", gsLen)
 
 	gsa := allocationv1.GameServerAllocation{ObjectMeta: metav1.ObjectMeta{Name: "gsa-1", Namespace: defaultNs},
 		Spec: allocationv1.GameServerAllocationSpec{},
@@ -489,7 +489,7 @@ func TestAllocatorAllocateOnGameServerUpdateError(t *testing.T) {
 	// without converter, we don't end up with at least one selector
 	gsa.Converter()
 	errs := gsa.Validate()
-	require.Len(t, errs, 0)
+	require.Empty(t, errs)
 	require.Len(t, gsa.Spec.Selectors, 1)
 
 	// try the private method
@@ -504,7 +504,7 @@ func TestAllocatorAllocateOnGameServerUpdateError(t *testing.T) {
 	// wait for all the gameservers to be in the cache
 	require.Eventuallyf(t, func() bool {
 		return a.allocationCache.cache.Len() == gsLen
-	}, 10*time.Second, time.Second, fmt.Sprintf("should be %d items in the cache", gsLen))
+	}, 10*time.Second, time.Second, "should be %d items in the cache", gsLen)
 
 	// try the public method
 	result, err := a.Allocate(ctx, gsa.DeepCopy())
@@ -544,10 +544,10 @@ func TestAllocatorRunLocalAllocations(t *testing.T) {
 
 		// This call initializes the cache
 		err := a.allocationCache.syncCache()
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		err = a.allocationCache.counter.Run(ctx, 0)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		gsa := &allocationv1.GameServerAllocation{
 			ObjectMeta: metav1.ObjectMeta{
@@ -558,7 +558,7 @@ func TestAllocatorRunLocalAllocations(t *testing.T) {
 			}}
 		gsa.ApplyDefaults()
 		errs := gsa.Validate()
-		require.Len(t, errs, 0)
+		require.Empty(t, errs)
 
 		// line up 3 in a batch
 		j1 := request{gsa: gsa.DeepCopy(), response: make(chan response, 1), ctx: context.Background()}
@@ -601,10 +601,10 @@ func TestAllocatorRunLocalAllocations(t *testing.T) {
 
 		// This call initializes the cache
 		err := a.allocationCache.syncCache()
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		err = a.allocationCache.counter.Run(ctx, 0)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		gsa := &allocationv1.GameServerAllocation{
 			ObjectMeta: metav1.ObjectMeta{
@@ -615,7 +615,7 @@ func TestAllocatorRunLocalAllocations(t *testing.T) {
 			}}
 		gsa.ApplyDefaults()
 		errs := gsa.Validate()
-		require.Len(t, errs, 0)
+		require.Empty(t, errs)
 
 		j1 := request{gsa: gsa.DeepCopy(), response: make(chan response, 1), ctx: context.Background()}
 		a.pendingRequests <- j1
@@ -635,10 +635,10 @@ func TestAllocatorRunLocalAllocations(t *testing.T) {
 
 		// This call initializes the cache
 		err := a.allocationCache.syncCache()
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		err = a.allocationCache.counter.Run(ctx, 0)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		gsa := &allocationv1.GameServerAllocation{
 			ObjectMeta: metav1.ObjectMeta{
@@ -649,7 +649,7 @@ func TestAllocatorRunLocalAllocations(t *testing.T) {
 			}}
 		gsa.ApplyDefaults()
 		errs := gsa.Validate()
-		require.Len(t, errs, 0)
+		require.Empty(t, errs)
 
 		reqCtx, reqCancel := context.WithTimeout(context.Background(), time.Millisecond)
 		reqCancel()
@@ -734,10 +734,10 @@ func TestAllocatorRunLocalAllocationsCountsAndLists(t *testing.T) {
 
 	// This call initializes the cache
 	err := a.allocationCache.syncCache()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	err = a.allocationCache.counter.Run(ctx, 0)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	READY := agonesv1.GameServerStateReady
 
@@ -1117,7 +1117,7 @@ func TestAllocatorCreateRestClientError(t *testing.T) {
 			SecretName: "secret-name",
 		}
 		_, err := a.createRemoteClusterDialOption(defaultNs, connectionInfo)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	})
 }
 

--- a/pkg/gameserverallocations/controller_test.go
+++ b/pkg/gameserverallocations/controller_test.go
@@ -190,14 +190,14 @@ func TestAllocationApiResource(t *testing.T) {
 	client := ts.Client()
 
 	resp, err := client.Get(ts.URL + "/apis/" + allocationv1.SchemeGroupVersion.String())
-	if !assert.Nil(t, err) {
+	if !assert.NoError(t, err) {
 		assert.FailNow(t, err.Error())
 	}
 	defer resp.Body.Close() // nolint: errcheck
 
 	list := &metav1.APIResourceList{}
 	err = json.NewDecoder(resp.Body).Decode(list)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	if assert.Len(t, list.APIResources, 1) {
 		assert.Equal(t, "gameserverallocation", list.APIResources[0].SingularName)
@@ -272,7 +272,7 @@ func TestMultiClusterAllocationFromLocal(t *testing.T) {
 		assert.Equal(t, gsa.Spec.Selectors[0].LabelSelector, ret.Spec.Selectors[0].LabelSelector)
 		assert.Equal(t, gsa.Namespace, ret.Namespace)
 		expectedState := allocationv1.GameServerAllocationAllocated
-		assert.True(t, expectedState == ret.Status.State, "Failed: %s vs %s", expectedState, ret.Status.State)
+		assert.Equal(t, expectedState, ret.Status.State, "Failed: %s vs %s", expectedState, ret.Status.State)
 	})
 
 	t.Run("Missing multicluster policy", func(t *testing.T) {
@@ -380,7 +380,7 @@ func TestMultiClusterAllocationFromLocal(t *testing.T) {
 		assert.Equal(t, gsa.Spec.Selectors[0].LabelSelector, ret.Spec.Selectors[0].LabelSelector)
 		assert.Equal(t, gsa.Namespace, ret.Namespace)
 		expectedState := allocationv1.GameServerAllocationUnAllocated
-		assert.True(t, expectedState == ret.Status.State, "Failed: %s vs %s", expectedState, ret.Status.State)
+		assert.Equal(t, expectedState, ret.Status.State, "Failed: %s vs %s", expectedState, ret.Status.State)
 	})
 }
 
@@ -429,10 +429,10 @@ func TestMultiClusterAllocationFromRemote(t *testing.T) {
 
 		// This call initializes the cache
 		err := c.allocator.allocationCache.syncCache()
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		err = c.allocator.allocationCache.counter.Run(ctx, 0)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		gsa := &allocationv1.GameServerAllocation{
 			ObjectMeta: metav1.ObjectMeta{
@@ -532,10 +532,10 @@ func TestMultiClusterAllocationFromRemote(t *testing.T) {
 
 		// This call initializes the cache
 		err := c.allocator.allocationCache.syncCache()
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		err = c.allocator.allocationCache.counter.Run(ctx, 0)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		gsa := &allocationv1.GameServerAllocation{
 			ObjectMeta: metav1.ObjectMeta{
@@ -554,7 +554,7 @@ func TestMultiClusterAllocationFromRemote(t *testing.T) {
 		if assert.Error(t, err) {
 			assert.Contains(t, err.Error(), "test error message")
 		}
-		assert.Truef(t, retry > 1, "Retry count %v. Expecting to retry on error.", retry)
+		assert.Greaterf(t, retry, 1, "Retry count %v. Expecting to retry on error.", retry)
 	})
 
 	t.Run("First server fails and second server succeeds", func(t *testing.T) {
@@ -611,10 +611,10 @@ func TestMultiClusterAllocationFromRemote(t *testing.T) {
 
 		// This call initializes the cache
 		err := c.allocator.allocationCache.syncCache()
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		err = c.allocator.allocationCache.counter.Run(ctx, 0)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		gsa := &allocationv1.GameServerAllocation{
 			ObjectMeta: metav1.ObjectMeta{
@@ -678,10 +678,10 @@ func TestMultiClusterAllocationFromRemote(t *testing.T) {
 
 		// This call initializes the cache
 		err := c.allocator.allocationCache.syncCache()
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		err = c.allocator.allocationCache.counter.Run(ctx, 0)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		gsa := &allocationv1.GameServerAllocation{
 			ObjectMeta: metav1.ObjectMeta{
@@ -700,7 +700,7 @@ func TestMultiClusterAllocationFromRemote(t *testing.T) {
 		assert.Error(t, err)
 		st, ok := status.FromError(err)
 		assert.True(t, ok)
-		assert.Equal(t, st.Code(), codes.DeadlineExceeded)
+		assert.Equal(t, codes.DeadlineExceeded, st.Code())
 		assert.Equal(t, 0, calls)
 	})
 	t.Run("First allocation fails and second succeeds on the same server", func(t *testing.T) {
@@ -751,10 +751,10 @@ func TestMultiClusterAllocationFromRemote(t *testing.T) {
 
 		// This call initializes the cache
 		err := c.allocator.allocationCache.syncCache()
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		err = c.allocator.allocationCache.counter.Run(ctx, 0)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		gsa := &allocationv1.GameServerAllocation{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/gameserverallocations/find_test.go
+++ b/pkg/gameserverallocations/find_test.go
@@ -72,7 +72,7 @@ func TestFindGameServerForAllocationPacked(t *testing.T) {
 				emptyGSA.ApplyDefaults()
 				emptyGSA.Converter()
 				allErrs := emptyGSA.Validate()
-				require.Len(t, allErrs, 0)
+				require.Empty(t, allErrs)
 				require.Len(t, emptyGSA.Spec.Selectors, 1)
 
 				gs, index, err := findGameServerForAllocation(emptyGSA, list)
@@ -190,7 +190,7 @@ func TestFindGameServerForAllocationPacked(t *testing.T) {
 				assert.Len(t, list, 8)
 
 				gs, index, err := findGameServerForAllocation(gsa, list)
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				assert.Equal(t, "node2", gs.Status.NodeName)
 				assert.Equal(t, gs, list[index])
 				assert.Equal(t, agonesv1.GameServerStateReady, gs.Status.State)
@@ -207,11 +207,11 @@ func TestFindGameServerForAllocationPacked(t *testing.T) {
 
 			gsa.ApplyDefaults()
 			allErrs := gsa.Validate()
-			require.Len(t, allErrs, 0)
+			require.Empty(t, allErrs)
 
 			twoLabelsGsa.ApplyDefaults()
 			allErrs = twoLabelsGsa.Validate()
-			require.Len(t, allErrs, 0)
+			require.Empty(t, allErrs)
 
 			controller, m := newFakeController()
 			c := controller.allocator.allocationCache
@@ -225,10 +225,10 @@ func TestFindGameServerForAllocationPacked(t *testing.T) {
 
 			// This call initializes the cache
 			err := c.syncCache()
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			err = c.counter.Run(ctx, 0)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			list := c.ListSortedGameServers(v.gsa)
 			v.test(t, list)
@@ -260,7 +260,7 @@ func TestFindGameServerForAllocationDistributed(t *testing.T) {
 	}
 	gsa.ApplyDefaults()
 	allErrs := gsa.Validate()
-	require.Len(t, allErrs, 0)
+	require.Empty(t, allErrs)
 
 	gsList := []agonesv1.GameServer{
 		{ObjectMeta: metav1.ObjectMeta{Name: "gs1", Namespace: defaultNs, Labels: labels},
@@ -288,10 +288,10 @@ func TestFindGameServerForAllocationDistributed(t *testing.T) {
 
 	// This call initializes the cache
 	err := c.syncCache()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	err = c.counter.Run(ctx, 0)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	list := c.ListSortedGameServers(gsa)
 	assert.Len(t, list, 6)

--- a/pkg/gameserverallocations/metrics_test.go
+++ b/pkg/gameserverallocations/metrics_test.go
@@ -192,7 +192,7 @@ func TestAllocationMetrics(t *testing.T) {
 		}}
 	gsa.ApplyDefaults()
 	errs := gsa.Validate()
-	require.Len(t, errs, 0)
+	require.Empty(t, errs)
 
 	result, err := a.Allocate(ctxAlloc, &gsa)
 	require.NoError(t, err)

--- a/pkg/gameserverallocations/processor/client.go
+++ b/pkg/gameserverallocations/processor/client.go
@@ -381,8 +381,9 @@ func (p *client) handleBatchResponse(batchResp *allocationpb.BatchResponse) {
 		p.batchMutex.RUnlock()
 
 		if exists {
-			// Track if response was processed successfully
-			responseProcessed := false
+			// Track if response was processed successfully. Every switch branch
+			// below sets this before it can be read.
+			var responseProcessed bool
 
 			switch result := respWrapper.Result.(type) {
 			case *allocationpb.ResponseWrapper_Response:

--- a/pkg/gameserverallocations/processor/handler.go
+++ b/pkg/gameserverallocations/processor/handler.go
@@ -16,6 +16,7 @@ package processor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
@@ -99,7 +100,7 @@ func (h *Handler) StreamBatches(stream allocationpb.Processor_StreamBatchesServe
 	for {
 		msg, err := stream.Recv()
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				handlerLogger.WithField(logFieldClientID, clientID).Debug("Stream closed by client")
 			} else {
 				handlerLogger.WithField(logFieldClientID, clientID).WithError(err).Warn("Stream receive error")

--- a/pkg/gameservers/controller.go
+++ b/pkg/gameservers/controller.go
@@ -273,7 +273,7 @@ func (ext *Extensions) creationMutationHandler(review admissionv1.AdmissionRevie
 	if err != nil {
 		// If the JSON is invalid during mutation, fall through to validation. This allows OpenAPI schema validation
 		// to proceed, resulting in a more user friendly error message.
-		return review, nil
+		return review, nil //nolint:nilerr // deliberate: see comment above.
 	}
 
 	// This is the main logic of this function
@@ -348,7 +348,7 @@ func (ext *Extensions) creationMutationHandlerPod(review admissionv1.AdmissionRe
 	if err != nil {
 		// If the JSON is invalid during mutation, fall through to validation. This allows OpenAPI schema validation
 		// to proceed, resulting in a more user friendly error message.
-		return review, nil
+		return review, nil //nolint:nilerr // deliberate: see comment above.
 	}
 
 	ext.baseLogger.WithField("pod.Name", pod.Name).Debug("creationMutationHandlerPod")

--- a/pkg/gameservers/controller_test.go
+++ b/pkg/gameservers/controller_test.go
@@ -141,10 +141,10 @@ func TestControllerSyncGameServer(t *testing.T) {
 		defer cancel()
 
 		err := c.portAllocator.Run(ctx)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		err = c.syncGameServer(ctx, "default/test")
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, 3, updateCount, "update reactor should fire thrice")
 		assert.True(t, podCreated, "pod should be created")
 	})
@@ -240,10 +240,10 @@ func TestControllerSyncGameServerWithInitSidecar(t *testing.T) {
 		defer cancel()
 
 		err := c.portAllocator.Run(ctx)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		err = c.syncGameServer(ctx, "default/test")
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, 3, updateCount, "update reactor should fire thrice")
 		assert.True(t, podCreated, "pod should be created")
 	})
@@ -274,7 +274,7 @@ func runReconcileDeleteGameServer(t *testing.T, fixture *agonesv1.GameServer) {
 	agonesWatch.Delete(fixture)
 
 	err := c.syncGameServer(ctx, "default/test")
-	assert.Nil(t, err, fmt.Sprintf("Shouldn't be an error from syncGameServer: %+v", err))
+	assert.NoError(t, err, "Shouldn't be an error from syncGameServer: %+v", err)
 	assert.False(t, podAction, "Nothing should happen to a Pod")
 }
 
@@ -328,10 +328,10 @@ func TestControllerSyncGameServerWithDevIP(t *testing.T) {
 		defer cancel()
 
 		err := c.portAllocator.Run(ctx)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		err = c.syncGameServer(ctx, "default/test")
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, 1, updateCount, "update reactor should fire once")
 	})
 
@@ -419,7 +419,7 @@ func TestControllerWatchGameServers(t *testing.T) {
 	fixture := agonesv1.GameServer{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}, Spec: newSingleContainerSpec()}
 	fixture.ApplyDefaults()
 	pod, err := fixture.Pod(agtesting.FakeAPIHooks{})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	pod.ObjectMeta.Name = pod.ObjectMeta.GenerateName + "-pod"
 
 	gsWatch := watch.NewFake()
@@ -460,7 +460,7 @@ func TestControllerWatchGameServers(t *testing.T) {
 
 	go func() {
 		err := c.Run(ctx, 1)
-		assert.Nil(t, err, "Run should not error")
+		assert.NoError(t, err, "Run should not error")
 	}()
 
 	logrus.Info("Adding first fixture")
@@ -504,7 +504,7 @@ func TestControllerWatchGameServers(t *testing.T) {
 
 	// add an unscheduled game pod
 	pod, err = fixture.Pod(agtesting.FakeAPIHooks{})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	pod.ObjectMeta.Name = pod.ObjectMeta.GenerateName + "-pod2"
 	podWatch.Add(pod)
 	noStateChange(podSynced)
@@ -745,7 +745,7 @@ func TestControllerSyncGameServerDeletionTimestamp(t *testing.T) {
 			Spec: newSingleContainerSpec()}
 		fixture.ApplyDefaults()
 		pod, err := fixture.Pod(agtesting.FakeAPIHooks{})
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		deleted := false
 		mocks.KubeClient.AddReactor("list", "pods", func(_ k8stesting.Action) (bool, runtime.Object, error) {
@@ -776,7 +776,7 @@ func TestControllerSyncGameServerDeletionTimestamp(t *testing.T) {
 			Spec: newSingleContainerSpec()}
 		fixture.ApplyDefaults()
 		pod, err := fixture.Pod(agtesting.FakeAPIHooks{})
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		mocks.KubeClient.AddReactor("list", "pods", func(_ k8stesting.Action) (bool, runtime.Object, error) {
 			return true, &corev1.PodList{Items: []corev1.Pod{*pod}}, nil
@@ -816,7 +816,7 @@ func TestControllerSyncGameServerDeletionTimestamp(t *testing.T) {
 		defer cancel()
 
 		result, err := c.syncGameServerDeletionTimestamp(ctx, fixture)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.True(t, updated, "gameserver should be updated, to remove the finaliser")
 		assert.Equal(t, fixture.ObjectMeta.Name, result.ObjectMeta.Name)
 		assert.Empty(t, result.ObjectMeta.Finalizers)
@@ -847,7 +847,7 @@ func TestControllerSyncGameServerDeletionTimestamp(t *testing.T) {
 		defer cancel()
 
 		result, err := c.syncGameServerDeletionTimestamp(ctx, fixture)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.True(t, updated, "gameserver should be updated, to remove the finaliser")
 		assert.Equal(t, fixture.ObjectMeta.Name, result.ObjectMeta.Name)
 		assert.Empty(t, result.ObjectMeta.Finalizers)
@@ -1166,7 +1166,7 @@ func TestControllerSyncGameServerCreatingState(t *testing.T) {
 		podCreated := false
 		gsUpdated := false
 		pod, err := fixture.Pod(agtesting.FakeAPIHooks{})
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		m.KubeClient.AddReactor("list", "pods", func(_ k8stesting.Action) (bool, runtime.Object, error) {
 			return true, &corev1.PodList{Items: []corev1.Pod{*pod}}, nil
@@ -1187,7 +1187,7 @@ func TestControllerSyncGameServerCreatingState(t *testing.T) {
 		defer cancel()
 
 		gs, err := c.syncGameServerCreatingState(ctx, fixture)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, agonesv1.GameServerStateStarting, gs.Status.State)
 		assert.False(t, podCreated, "Pod should not have been created")
 		assert.True(t, gsUpdated, "GameServer should have been updated")
@@ -1215,7 +1215,7 @@ func TestControllerSyncGameServerCreatingState(t *testing.T) {
 		defer cancel()
 
 		gs, err := c.syncGameServerCreatingState(ctx, fixture)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		assert.True(t, podCreated, "attempt should have been made to create a pod")
 		assert.True(t, gsUpdated, "GameServer should be updated")
@@ -1252,7 +1252,7 @@ func TestControllerSyncGameServerStartingState(t *testing.T) {
 		gsFixture := newFixture()
 		gsFixture.ApplyDefaults()
 		pod, err := gsFixture.Pod(agtesting.FakeAPIHooks{})
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		pod.Spec.NodeName = nodeFixtureName
 		pod.Status.PodIPs = []corev1.PodIP{{IP: ipv6Fixture}}
 		gsUpdated := false
@@ -1279,7 +1279,7 @@ func TestControllerSyncGameServerStartingState(t *testing.T) {
 
 		assert.True(t, gsUpdated)
 		assert.Equal(t, gs.Status.NodeName, node.ObjectMeta.Name)
-		assert.Equal(t, gs.Status.Address, ipFixture)
+		assert.Equal(t, ipFixture, gs.Status.Address)
 		assert.Equal(t, []corev1.NodeAddress{
 			{Address: ipFixture, Type: "ExternalIP"},
 			{Address: ipv6Fixture, Type: "PodIP"},
@@ -1630,8 +1630,8 @@ func TestControllerCreateGameServerPod(t *testing.T) {
 			assert.Equal(t, "REQUESTS_RATE_LIMIT", sidecarContainer.Env[4].Name)
 			assert.Equal(t, "500ms", sidecarContainer.Env[4].Value)
 			assert.Equal(t, string(fixture.Spec.SdkServer.LogLevel), sidecarContainer.Env[3].Value)
-			assert.Equal(t, *sidecarContainer.SecurityContext.AllowPrivilegeEscalation, false)
-			assert.Equal(t, *sidecarContainer.SecurityContext.RunAsNonRoot, true)
+			assert.False(t, *sidecarContainer.SecurityContext.AllowPrivilegeEscalation)
+			assert.True(t, *sidecarContainer.SecurityContext.RunAsNonRoot)
 			assert.Equal(t, *sidecarContainer.SecurityContext.RunAsUser, int64(sidecarRunAsUser))
 
 			assert.Equal(t, fixture.Spec.Ports[0].HostPort, gsContainer.Ports[0].HostPort)
@@ -1678,7 +1678,7 @@ func TestControllerCreateGameServerPod(t *testing.T) {
 		})
 
 		_, err := c.createGameServerPod(context.Background(), fixture)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.True(t, created)
 	})
 
@@ -2140,7 +2140,7 @@ func TestControllerSyncGameServerShutdownState(t *testing.T) {
 		defer cancel()
 
 		err := c.syncGameServerShutdownState(ctx, gsFixture)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.True(t, checkDeleted, "GameServer should be deleted")
 		assert.Contains(t, <-mocks.FakeRecorder.Events, "Deletion started")
 	})

--- a/pkg/gameservers/health_test.go
+++ b/pkg/gameservers/health_test.go
@@ -384,7 +384,7 @@ func TestHealthControllerSyncGameServer(t *testing.T) {
 			defer cancel()
 
 			err := hc.syncGameServer(ctx, "default/test")
-			assert.Nil(t, err, err)
+			assert.NoError(t, err)
 			assert.True(t, got, "GameServers Should be got!")
 
 			assert.Equal(t, test.expected.updated, updated, "updated test")

--- a/pkg/gameservers/migration_test.go
+++ b/pkg/gameservers/migration_test.go
@@ -259,7 +259,7 @@ func TestMigrationControllerRun(t *testing.T) {
 
 	go func() {
 		err := c.Run(ctx, 1)
-		assert.Nil(t, err, "Run should not error")
+		assert.NoError(t, err, "Run should not error")
 	}()
 
 	noChange := func() {

--- a/pkg/gameservers/missing_test.go
+++ b/pkg/gameservers/missing_test.go
@@ -215,7 +215,7 @@ func TestMissingPodControllerRun(t *testing.T) {
 
 	go func() {
 		err := c.Run(ctx, 1)
-		assert.Nil(t, err, "Run should not error")
+		assert.NoError(t, err, "Run should not error")
 	}()
 
 	noChange := func() {

--- a/pkg/gameservers/pernodecounter_test.go
+++ b/pkg/gameservers/pernodecounter_test.go
@@ -79,7 +79,7 @@ func TestPerNodeCounterGameServerEvents(t *testing.T) {
 	require.Eventuallyf(t, func() bool {
 		counts = pnc.Counts()
 		return len(counts) == 1 && int64(0) == counts[name1].Ready
-	}, 5*time.Second, time.Second, "Ready should be 0, but is instead", counts[name1].Ready)
+	}, 5*time.Second, time.Second, "Ready should be 0, but is instead %d", counts[name1].Ready)
 	assert.Equal(t, int64(1), counts[name1].Allocated)
 
 	gs.Status.State = agonesv1.GameServerStateShutdown
@@ -88,7 +88,7 @@ func TestPerNodeCounterGameServerEvents(t *testing.T) {
 	require.Eventuallyf(t, func() bool {
 		counts = pnc.Counts()
 		return len(counts) == 1 && int64(0) == counts[name1].Allocated
-	}, 5*time.Second, time.Second, "Allocated should be 0, but is instead", counts[name1].Allocated)
+	}, 5*time.Second, time.Second, "Allocated should be 0, but is instead %d", counts[name1].Allocated)
 	assert.Equal(t, int64(0), counts[name1].Ready)
 
 	gs.ObjectMeta.Name = "gs2"
@@ -118,7 +118,7 @@ func TestPerNodeCounterGameServerEvents(t *testing.T) {
 	require.Eventuallyf(t, func() bool {
 		counts = pnc.Counts()
 		return len(counts) == 2 && int64(1) == counts[name2].Allocated
-	}, 5*time.Second, time.Second, "Allocated should be 1, but is instead", counts[name2].Allocated)
+	}, 5*time.Second, time.Second, "Allocated should be 1, but is instead %d", counts[name2].Allocated)
 	assert.Equal(t, int64(0), counts[name1].Ready)
 	assert.Equal(t, int64(0), counts[name1].Allocated)
 	assert.Equal(t, int64(1), counts[name2].Ready)

--- a/pkg/gameservers/succeeded_test.go
+++ b/pkg/gameservers/succeeded_test.go
@@ -243,7 +243,7 @@ func TestSucceededControllerRun(t *testing.T) {
 
 	go func() {
 		err := c.Run(ctx, 1)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}()
 
 	select {
@@ -292,7 +292,7 @@ func TestSucceededControllerRunGameServerResync(t *testing.T) {
 
 	go func() {
 		err := c.Run(ctx, 1)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	}()
 
 	noChange := func(reason string) {

--- a/pkg/gameserversets/allocation_overflow_test.go
+++ b/pkg/gameserversets/allocation_overflow_test.go
@@ -55,7 +55,7 @@ func TestAllocationOverflowControllerWatchGameServers(t *testing.T) {
 
 	go func() {
 		err := c.Run(ctx)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}()
 
 	change := func() string {
@@ -148,7 +148,7 @@ func TestAllocationOverflowSyncGameServerSet(t *testing.T) {
 		cancel := run(c, m, gsSet, func(action k8stesting.Action) (bool, runtime.Object, error) {
 			ua := action.(k8stesting.UpdateAction)
 			gs := ua.GetObject().(*agonesv1.GameServer)
-			require.Equal(t, gs.Status.State, agonesv1.GameServerStateAllocated)
+			require.Equal(t, agonesv1.GameServerStateAllocated, gs.Status.State)
 			require.Equal(t, "green", gs.ObjectMeta.Labels["colour"])
 
 			count++
@@ -183,7 +183,7 @@ func TestAllocationOverflowSyncGameServerSet(t *testing.T) {
 		cancel := run(c, m, gsSet, func(action k8stesting.Action) (bool, runtime.Object, error) {
 			ua := action.(k8stesting.UpdateAction)
 			gs := ua.GetObject().(*agonesv1.GameServer)
-			require.Equal(t, gs.Status.State, agonesv1.GameServerStateAllocated)
+			require.Equal(t, agonesv1.GameServerStateAllocated, gs.Status.State)
 			require.Equal(t, "green", gs.ObjectMeta.Labels["colour"])
 
 			count++

--- a/pkg/gameserversets/controller_test.go
+++ b/pkg/gameserversets/controller_test.go
@@ -606,21 +606,21 @@ func TestGameServerSetDropCountsAndListsStatus(t *testing.T) {
 	flag = string(utilruntime.FeatureCountsAndLists) + "=true"
 	require.NoError(t, utilruntime.ParseFeatures(flag))
 	err := c.syncGameServerSetStatus(context.Background(), gss, gsList)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, updated)
 
 	updated = false
 	flag = string(utilruntime.FeatureCountsAndLists) + "=false"
 	require.NoError(t, utilruntime.ParseFeatures(flag))
 	err = c.syncGameServerSetStatus(context.Background(), gss, gsList)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, updated)
 
 	updated = false
 	flag = string(utilruntime.FeatureCountsAndLists) + "=true"
 	require.NoError(t, utilruntime.ParseFeatures(flag))
 	err = c.syncGameServerSetStatus(context.Background(), gss, gsList)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, updated)
 }
 
@@ -654,7 +654,7 @@ func TestControllerWatchGameServers(t *testing.T) {
 
 	go func() {
 		err := c.Run(ctx, 1)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	}()
 
 	f := func() string {
@@ -772,7 +772,7 @@ func TestSyncGameServerSet(t *testing.T) {
 		m.AgonesClient.AddReactor("update", "gameservers", func(action k8stesting.Action) (bool, runtime.Object, error) {
 			ua := action.(k8stesting.UpdateAction)
 			gs := ua.GetObject().(*agonesv1.GameServer)
-			assert.Equal(t, gs.Status.State, agonesv1.GameServerStateShutdown)
+			assert.Equal(t, agonesv1.GameServerStateShutdown, gs.Status.State)
 
 			updated = true
 			assert.Equal(t, "test-0", gs.GetName())
@@ -818,7 +818,7 @@ func TestSyncGameServerSet(t *testing.T) {
 		m.AgonesClient.AddReactor("update", "gameservers", func(action k8stesting.Action) (bool, runtime.Object, error) {
 			ua := action.(k8stesting.UpdateAction)
 			gs := ua.GetObject().(*agonesv1.GameServer)
-			assert.Equal(t, gs.Status.State, agonesv1.GameServerStateShutdown)
+			assert.Equal(t, agonesv1.GameServerStateShutdown, gs.Status.State)
 
 			updated = true
 			assert.Equal(t, "test-0", gs.GetName())
@@ -864,7 +864,7 @@ func TestSyncGameServerSet(t *testing.T) {
 		m.AgonesClient.AddReactor("update", "gameservers", func(action k8stesting.Action) (bool, runtime.Object, error) {
 			ua := action.(k8stesting.UpdateAction)
 			gs := ua.GetObject().(*agonesv1.GameServer)
-			assert.Equal(t, gs.Status.State, agonesv1.GameServerStateShutdown)
+			assert.Equal(t, agonesv1.GameServerStateShutdown, gs.Status.State)
 
 			updated = true
 			assert.Equal(t, "test-0", gs.GetName())
@@ -936,7 +936,7 @@ func TestSyncGameServerSet(t *testing.T) {
 		m.AgonesClient.AddReactor("update", "gameservers", func(action k8stesting.Action) (bool, runtime.Object, error) {
 			ua := action.(k8stesting.UpdateAction)
 			gs := ua.GetObject().(*agonesv1.GameServer)
-			require.Equal(t, gs.Status.State, agonesv1.GameServerStateShutdown)
+			require.Equal(t, agonesv1.GameServerStateShutdown, gs.Status.State)
 
 			deleted = append(deleted, gs.ObjectMeta.Name)
 			return true, nil, nil
@@ -977,7 +977,7 @@ func TestControllerSyncUnhealthyGameServers(t *testing.T) {
 			ua := action.(k8stesting.UpdateAction)
 			gs := ua.GetObject().(*agonesv1.GameServer)
 
-			assert.Equal(t, gs.Status.State, agonesv1.GameServerStateShutdown)
+			assert.Equal(t, agonesv1.GameServerStateShutdown, gs.Status.State)
 
 			updatedCount++
 			return true, nil, nil
@@ -987,7 +987,7 @@ func TestControllerSyncUnhealthyGameServers(t *testing.T) {
 		defer cancel()
 
 		err := c.deleteGameServers(ctx, gsSet, []*agonesv1.GameServer{gs1, gs2, gs3})
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		assert.Equal(t, 3, updatedCount, "Updates should have occurred")
 	})
@@ -998,7 +998,7 @@ func TestControllerSyncUnhealthyGameServers(t *testing.T) {
 			ua := action.(k8stesting.UpdateAction)
 			gs := ua.GetObject().(*agonesv1.GameServer)
 
-			assert.Equal(t, gs.Status.State, agonesv1.GameServerStateShutdown)
+			assert.Equal(t, agonesv1.GameServerStateShutdown, gs.Status.State)
 
 			return true, nil, errors.New("update-err")
 		})
@@ -1036,7 +1036,7 @@ func TestSyncMoreGameServers(t *testing.T) {
 		defer cancel()
 
 		err := c.addMoreGameServers(ctx, gsSet, expected)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, expected, count)
 		agtesting.AssertEventContains(t, m.FakeRecorder.Events, "SuccessfulCreate")
 	})
@@ -1085,7 +1085,7 @@ func TestControllerSyncGameServerSetStatus(t *testing.T) {
 
 		list := []*agonesv1.GameServer{{Status: agonesv1.GameServerStatus{State: agonesv1.GameServerStateReady}}}
 		err := c.syncGameServerSetStatus(context.Background(), gsSet, list)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.True(t, updated)
 	})
 
@@ -1117,7 +1117,7 @@ func TestControllerSyncGameServerSetStatus(t *testing.T) {
 			{Status: agonesv1.GameServerStatus{State: agonesv1.GameServerStateAllocated}},
 		}
 		err := c.syncGameServerSetStatus(context.Background(), gsSet, list)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.True(t, updated)
 	})
 }

--- a/pkg/gameserversets/metrics_test.go
+++ b/pkg/gameserversets/metrics_test.go
@@ -80,7 +80,7 @@ func TestGSSMetrics(t *testing.T) {
 	defer cancel()
 
 	err := c.addMoreGameServers(ctx, gsSet, expected)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, expected, count)
 	agtesting.AssertEventContains(t, m.FakeRecorder.Events, "SuccessfulCreate")
 

--- a/pkg/metrics/controller_test.go
+++ b/pkg/metrics/controller_test.go
@@ -123,8 +123,8 @@ func assertMetricData(t *testing.T, c *fakeController, f func(), reader *metrice
 		}
 		require.NotNil(ct, wantedMetric, "No metric found with name: %s", metricName)
 
-		assert.Equal(ct, len(expectedValuesAsMap), len(expected), "Multiple entries in 'expected' slice have the exact same labels")
-		assert.Equalf(ct, len(expectedValuesAsMap), len(wantedMetric.TimeSeries), "number of timeseries does not match under metric: %v", metricName)
+		assert.Len(ct, expected, len(expectedValuesAsMap), "Multiple entries in 'expected' slice have the exact same labels")
+		assert.Lenf(ct, wantedMetric.TimeSeries, len(expectedValuesAsMap), "number of timeseries does not match under metric: %v", metricName)
 		for _, tsd := range wantedMetric.TimeSeries {
 			actualLabelValues := make([]string, len(tsd.LabelValues))
 			for i, k := range tsd.LabelValues {
@@ -133,7 +133,7 @@ func assertMetricData(t *testing.T, c *fakeController, f func(), reader *metrice
 			e, ok := expectedValuesAsMap[serialize(actualLabelValues)]
 			assert.True(ct, ok, "no TimeSeries found with labels: %v", actualLabelValues)
 			assert.Equal(ct, e.labels, actualLabelValues, "label values don't match")
-			assert.Equal(ct, 1, len(tsd.Points), "assertMetricDataValues can only handle a single Point in a TimeSeries")
+			assert.Len(ct, tsd.Points, 1, "assertMetricDataValues can only handle a single Point in a TimeSeries")
 			assert.Equal(ct, e.val, tsd.Points[0].Value, "metric: %s, tags: %v, values don't match; got: %v, want: %v", metricName, tsd.LabelValues, tsd.Points[0].Value, e.val)
 		}
 	}, 10*time.Second, 100*time.Millisecond)
@@ -751,10 +751,10 @@ func TestCalcDuration(t *testing.T) {
 			} else {
 				assert.NoError(t, err, "Unable to caculate duration of a particular state")
 			}
-			assert.Equal(t, tc.expected.duration, duration, "Time diff should be calculated properly")
+			assert.InDelta(t, tc.expected.duration, duration, 0.0001, "Time diff should be calculated properly")
 		})
 	}
-	assert.Len(t, c.gameServerStateLastChange.Keys(), 0, "We should not have any keys after the test")
+	assert.Empty(t, c.gameServerStateLastChange.Keys(), "We should not have any keys after the test")
 }
 
 func TestIsSystemNode(t *testing.T) {

--- a/pkg/metrics/exporter_test.go
+++ b/pkg/metrics/exporter_test.go
@@ -285,7 +285,7 @@ func setupGameServerAllocation(t *testing.T, ctrl *fakeController) {
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		gs, err := ctrl.gameServerLister.GameServers(gs.ObjectMeta.Namespace).Get(gs.ObjectMeta.Name)
 		require.NoError(collect, err)
-		assert.Equal(collect, gs.Status.State, agonesv1.GameServerStateAllocated)
+		assert.Equal(collect, agonesv1.GameServerStateAllocated, gs.Status.State)
 	}, 5*time.Second, time.Second)
 	ctrl.collect()
 }

--- a/pkg/metrics/util_test.go
+++ b/pkg/metrics/util_test.go
@@ -84,7 +84,7 @@ func (c *fakeController) close() {
 func (c *fakeController) run(t *testing.T) {
 	go func() {
 		err := c.Controller.Run(c.ctx, 1)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	}()
 	c.sync()
 }

--- a/pkg/portallocator/portallocator_test.go
+++ b/pkg/portallocator/portallocator_test.go
@@ -15,7 +15,6 @@
 package portallocator
 
 import (
-	"fmt"
 	"strconv"
 	"sync"
 	"testing"
@@ -174,10 +173,10 @@ func TestPortRangeAllocatorAllocate(t *testing.T) {
 		// no port
 		gsCopy = fixture.DeepCopy()
 		gsCopy.Spec.Ports = nil
-		assert.Len(t, gsCopy.Spec.Ports, 0)
+		assert.Empty(t, gsCopy.Spec.Ports)
 		pa.Allocate(gsCopy)
 		assert.Nil(t, gsCopy.Spec.Ports)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, 12, countTotalAllocatedPorts(pa))
 	})
 
@@ -397,7 +396,9 @@ func TestPortRangeAllocatorMultithreadAllocate(t *testing.T) {
 			for x := 0; x < 10; x++ {
 				logrus.WithField("x", x).WithField("i", i).Info("allocating!")
 				gs := pa.Allocate(fixture.DeepCopy())
-				require.NotNil(t, gs)
+				if !assert.NotNil(t, gs) {
+					continue
+				}
 				for _, p := range gs.Spec.Ports {
 					assert.NotEmpty(t, p.HostPort)
 				}
@@ -447,7 +448,7 @@ func TestPortRangeAllocatorDeAllocate(t *testing.T) {
 
 		pa.DeAllocate(gs)
 		assert.Equal(t, 0, countAllocatedPorts(pa, port.HostPort))
-		assert.Len(t, pa.gameServerRegistry, 0)
+		assert.Empty(t, pa.gameServerRegistry)
 	}
 }
 
@@ -653,7 +654,7 @@ func TestTakePortAllocation(t *testing.T) {
 	for i, row := range fixture {
 		for p, taken := range row {
 			if i != 0 && p != 2 {
-				assert.False(t, taken, fmt.Sprintf("row %d and port %d should be false", i, p))
+				assert.False(t, taken, "row %d and port %d should be false", i, p)
 			}
 		}
 	}

--- a/pkg/sdkserver/helper_test.go
+++ b/pkg/sdkserver/helper_test.go
@@ -41,14 +41,14 @@ func testHTTPHealth(t *testing.T, url string, expectedResponse string, expectedS
 		if resp != nil {
 			defer resp.Body.Close() // nolint: errcheck
 			body, err := io.ReadAll(resp.Body)
-			assert.Nil(t, err, "(%s) read response error should be nil: %v", url, err)
+			assert.NoError(t, err, "(%s) read response error should be nil: %v", url, err)
 			assert.Equal(t, expectedStatus, resp.StatusCode, "url: %s", url)
 			assert.Equal(t, []byte(expectedResponse), body, "(%s) response body should be '%s'", url, expectedResponse)
 		}
 
 		return true, nil
 	})
-	assert.Nil(t, err, "Timeout on %s health check, %v", url, err)
+	assert.NoError(t, err, "Timeout on %s health check, %v", url, err)
 }
 
 // emptyMockStream is the mock of the SDK_HealthServer for streaming

--- a/pkg/sdkserver/localsdk.go
+++ b/pkg/sdkserver/localsdk.go
@@ -181,6 +181,7 @@ func NewLocalSDKServer(filePath string, testSdkName string) (*LocalSDKServer, er
 // GenerateUID - generate gameserver UID at random for testing
 func (l *LocalSDKServer) GenerateUID() {
 	// Generating Random UID
+	//nolint:gosec // G404: a stand-in UID for local testing, never a security boundary.
 	seededRand := rand.New(
 		rand.NewSource(time.Now().UnixNano()))
 	UID := fmt.Sprintf("%d", seededRand.Int())
@@ -298,7 +299,7 @@ func (l *LocalSDKServer) Shutdown(context.Context, *sdk.Empty) (*sdk.Empty, erro
 func (l *LocalSDKServer) Health(stream sdk.SDK_HealthServer) error {
 	for {
 		_, err := stream.Recv()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			l.logger.Info("Health stream closed.")
 			return stream.SendAndClose(&sdk.Empty{})
 		}
@@ -743,7 +744,7 @@ func (l *LocalSDKServer) UpdateList(_ context.Context, in *beta.UpdateListReques
 	if GameServerListMaxCapacity == 0 {
 		err := l.GsLocalListsMaxItems()
 		if err != nil {
-			return nil, fmt.Errorf("%v", err)
+			return nil, fmt.Errorf("%w", err)
 		}
 	}
 

--- a/pkg/sdkserver/localsdk_test.go
+++ b/pkg/sdkserver/localsdk_test.go
@@ -45,13 +45,13 @@ func TestLocal(t *testing.T) {
 	ctx := context.Background()
 	e := &sdk.Empty{}
 	l, err := NewLocalSDKServer("", "")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	_, err = l.Ready(ctx, e)
-	assert.Nil(t, err, "Ready should not error")
+	assert.NoError(t, err, "Ready should not error")
 
 	_, err = l.Shutdown(ctx, e)
-	assert.Nil(t, err, "Shutdown should not error")
+	assert.NoError(t, err, "Shutdown should not error")
 
 	wg := sync.WaitGroup{}
 	wg.Add(1)
@@ -59,7 +59,7 @@ func TestLocal(t *testing.T) {
 
 	go func() {
 		err = l.Health(stream)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		wg.Done()
 	}()
 
@@ -69,7 +69,7 @@ func TestLocal(t *testing.T) {
 	wg.Wait()
 
 	gs, err := l.GetGameServer(ctx, e)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	defaultGameServer := defaultGs()
 	// do this to adjust for any time differences.
@@ -107,13 +107,13 @@ func TestLocalSDKWithGameServer(t *testing.T) {
 
 	fixture := &agonesv1.GameServer{ObjectMeta: metav1.ObjectMeta{Name: "stuff"}}
 	path, err := gsToTmpFile(fixture.DeepCopy())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	l, err := NewLocalSDKServer(path, "")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	gs, err := l.GetGameServer(ctx, e)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, fixture.ObjectMeta.Name, gs.ObjectMeta.Name)
 }
@@ -130,13 +130,13 @@ func TestLocalSDKWithLogLevel(t *testing.T) {
 		},
 	}
 	path, err := gsToTmpFile(fixture.DeepCopy())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	l, err := NewLocalSDKServer(path, "test")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	_, err = l.GetGameServer(ctx, e)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// Check if the LocalSDKServer's logger.LogLevel equal fixture's
 	assert.Equal(t, string(fixture.Spec.SdkServer.LogLevel), l.logger.Logger.Level.String())
@@ -165,10 +165,10 @@ func TestLocalSDKServerSetLabel(t *testing.T) {
 			ctx := context.Background()
 			e := &sdk.Empty{}
 			path, err := gsToTmpFile(v.gs)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			l, err := NewLocalSDKServer(path, "")
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			kv := &sdk.KeyValue{Key: "foo", Value: "bar"}
 
 			stream := newGameServerMockStream()
@@ -177,7 +177,7 @@ func TestLocalSDKServerSetLabel(t *testing.T) {
 			go func() {
 				defer wg.Done()
 				err := l.WatchGameServer(e, stream)
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 			}()
 			assertInitialWatchUpdate(t, stream)
 
@@ -191,14 +191,14 @@ func TestLocalSDKServerSetLabel(t *testing.T) {
 
 				return ret, nil
 			})
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			_, err = l.SetLabel(ctx, kv)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			gs, err := l.GetGameServer(ctx, e)
-			assert.Nil(t, err)
-			assert.Equal(t, gs.ObjectMeta.Labels[metadataPrefix+"foo"], "bar")
+			assert.NoError(t, err)
+			assert.Equal(t, "bar", gs.ObjectMeta.Labels[metadataPrefix+"foo"])
 
 			assertWatchUpdate(t, stream, "bar", func(gs *sdk.GameServer) interface{} {
 				return gs.ObjectMeta.Labels[metadataPrefix+"foo"]
@@ -233,10 +233,10 @@ func TestLocalSDKServerSetAnnotation(t *testing.T) {
 			ctx := context.Background()
 			e := &sdk.Empty{}
 			path, err := gsToTmpFile(v.gs)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			l, err := NewLocalSDKServer(path, "")
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			kv := &sdk.KeyValue{Key: "bar", Value: "foo"}
 
@@ -246,7 +246,7 @@ func TestLocalSDKServerSetAnnotation(t *testing.T) {
 			go func() {
 				defer wg.Done()
 				err := l.WatchGameServer(e, stream)
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 			}()
 			assertInitialWatchUpdate(t, stream)
 
@@ -260,14 +260,14 @@ func TestLocalSDKServerSetAnnotation(t *testing.T) {
 
 				return ret, nil
 			})
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			_, err = l.SetAnnotation(ctx, kv)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			gs, err := l.GetGameServer(ctx, e)
-			assert.Nil(t, err)
-			assert.Equal(t, gs.ObjectMeta.Annotations[metadataPrefix+"bar"], "foo")
+			assert.NoError(t, err)
+			assert.Equal(t, "foo", gs.ObjectMeta.Annotations[metadataPrefix+"bar"])
 
 			assertWatchUpdate(t, stream, "foo", func(gs *sdk.GameServer) interface{} {
 				return gs.ObjectMeta.Annotations[metadataPrefix+"bar"]
@@ -284,16 +284,16 @@ func TestLocalSDKServerWatchGameServer(t *testing.T) {
 
 	fixture := &agonesv1.GameServer{ObjectMeta: metav1.ObjectMeta{Name: "stuff"}}
 	path, err := gsToTmpFile(fixture)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	e := &sdk.Empty{}
 	l, err := NewLocalSDKServer(path, "")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	stream := newGameServerMockStream()
 	go func() {
 		err := l.WatchGameServer(e, stream)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	}()
 	assertInitialWatchUpdate(t, stream)
 
@@ -311,10 +311,10 @@ func TestLocalSDKServerWatchGameServer(t *testing.T) {
 	assertNoWatchUpdate(t, stream)
 	fixture.ObjectMeta.Annotations = map[string]string{"foo": "bar"}
 	j, err := json.Marshal(fixture)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	err = os.WriteFile(path, j, os.ModeDevice)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assertWatchUpdate(t, stream, "bar", func(gs *sdk.GameServer) interface{} {
 		return gs.ObjectMeta.Annotations["foo"]
@@ -334,12 +334,12 @@ func TestLocalSDKServerPlayerCapacity(t *testing.T) {
 	path, err := gsToTmpFile(fixture)
 	assert.NoError(t, err)
 	l, err := NewLocalSDKServer(path, "")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	stream := newGameServerMockStream()
 	go func() {
 		err := l.WatchGameServer(&sdk.Empty{}, stream)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	}()
 	assertInitialWatchUpdate(t, stream)
 
@@ -385,7 +385,7 @@ func TestLocalSDKServerPlayerConnectAndDisconnectWithoutPlayerTracking(t *testin
 	require.NoError(t, runtime.ParseFeatures(string(runtime.FeaturePlayerTracking)+"=false"))
 
 	l, err := NewLocalSDKServer("", "")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	e := &alpha.Empty{}
 	capacity, err := l.GetPlayerCapacity(context.Background(), e)
@@ -478,13 +478,13 @@ func TestLocalSDKServerPlayerConnectAndDisconnect(t *testing.T) {
 			} else {
 				l, err = NewLocalSDKServer("", "")
 			}
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			l.SetTestMode(v.testMode)
 
 			stream := newGameServerMockStream()
 			go func() {
 				err := l.WatchGameServer(&sdk.Empty{}, stream)
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 			}()
 			assertInitialWatchUpdate(t, stream)
 
@@ -629,12 +629,12 @@ func TestLocalSDKServerGetCounter(t *testing.T) {
 	path, err := gsToTmpFile(fixture)
 	assert.NoError(t, err)
 	l, err := NewLocalSDKServer(path, "")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	stream := newGameServerMockStream()
 	go func() {
 		err := l.WatchGameServer(&sdk.Empty{}, stream)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	}()
 	assertInitialWatchUpdate(t, stream)
 
@@ -705,12 +705,12 @@ func TestLocalSDKServerUpdateCounter(t *testing.T) {
 	path, err := gsToTmpFile(fixture)
 	assert.NoError(t, err)
 	l, err := NewLocalSDKServer(path, "")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	stream := newGameServerMockStream()
 	go func() {
 		err := l.WatchGameServer(&sdk.Empty{}, stream)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	}()
 	assertInitialWatchUpdate(t, stream)
 
@@ -853,12 +853,12 @@ func TestLocalSDKServerGetList(t *testing.T) {
 	path, err := gsToTmpFile(fixture)
 	assert.NoError(t, err)
 	l, err := NewLocalSDKServer(path, "")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	stream := newGameServerMockStream()
 	go func() {
 		err := l.WatchGameServer(&sdk.Empty{}, stream)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	}()
 	assertInitialWatchUpdate(t, stream)
 
@@ -930,12 +930,12 @@ func TestLocalSDKServerUpdateList(t *testing.T) {
 	path, err := gsToTmpFile(fixture)
 	assert.NoError(t, err)
 	l, err := NewLocalSDKServer(path, "")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	stream := newGameServerMockStream()
 	go func() {
 		err := l.WatchGameServer(&sdk.Empty{}, stream)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	}()
 	assertInitialWatchUpdate(t, stream)
 
@@ -1126,12 +1126,12 @@ func TestLocalSDKServerAddListValue(t *testing.T) {
 	path, err := gsToTmpFile(fixture)
 	assert.NoError(t, err)
 	l, err := NewLocalSDKServer(path, "")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	stream := newGameServerMockStream()
 	go func() {
 		err := l.WatchGameServer(&sdk.Empty{}, stream)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	}()
 	assertInitialWatchUpdate(t, stream)
 
@@ -1218,12 +1218,12 @@ func TestLocalSDKServerRemoveListValue(t *testing.T) {
 	path, err := gsToTmpFile(fixture)
 	assert.NoError(t, err)
 	l, err := NewLocalSDKServer(path, "")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	stream := newGameServerMockStream()
 	go func() {
 		err := l.WatchGameServer(&sdk.Empty{}, stream)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	}()
 	assertInitialWatchUpdate(t, stream)
 
@@ -1287,37 +1287,37 @@ func TestLocalSDKServerRemoveListValue(t *testing.T) {
 func TestLocalSDKServerStateUpdates(t *testing.T) {
 	t.Parallel()
 	l, err := NewLocalSDKServer("", "")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	ctx := context.Background()
 	e := &sdk.Empty{}
 	_, err = l.Ready(ctx, e)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	gs, err := l.GetGameServer(ctx, e)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, gs.Status.State, string(agonesv1.GameServerStateReady))
 
 	seconds := &sdk.Duration{Seconds: 2}
 	_, err = l.Reserve(ctx, seconds)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	gs, err = l.GetGameServer(ctx, e)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, gs.Status.State, string(agonesv1.GameServerStateReserved))
 
 	_, err = l.Allocate(ctx, e)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	gs, err = l.GetGameServer(ctx, e)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, gs.Status.State, string(agonesv1.GameServerStateAllocated))
 
 	_, err = l.Shutdown(ctx, e)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	gs, err = l.GetGameServer(ctx, e)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, gs.Status.State, string(agonesv1.GameServerStateShutdown))
 }
 
@@ -1326,7 +1326,7 @@ func TestSDKConformanceFunctionality(t *testing.T) {
 	t.Parallel()
 
 	l, err := NewLocalSDKServer("", "")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	l.testMode = true
 	l.recordRequest("")
 	l.gs = &sdk.GameServer{ObjectMeta: &sdk.GameServer_ObjectMeta{Name: "empty"}}
@@ -1360,7 +1360,7 @@ func TestSDKConformanceFunctionality(t *testing.T) {
 func TestAlphaSDKConformanceFunctionality(t *testing.T) {
 	t.Parallel()
 	lStable, err := NewLocalSDKServer("", "")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	v := int64(0)
 	lStable.recordRequestWithValue("setplayercapacity", strconv.FormatInt(v, 10), "PlayerCapacity")
 	lStable.recordRequestWithValue("isplayerconnected", "", "PlayerIDs")
@@ -1370,7 +1370,7 @@ func TestAlphaSDKConformanceFunctionality(t *testing.T) {
 
 	require.NoError(t, runtime.ParseFeatures(string(runtime.FeaturePlayerTracking)+"=true"))
 	l, err := NewLocalSDKServer("", "")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	l.testMode = true
 	l.recordRequestWithValue("setplayercapacity", strconv.FormatInt(v, 10), "PlayerCapacity")
 	l.recordRequestWithValue("isplayerconnected", "", "PlayerIDs")

--- a/pkg/sdkserver/sdkserver.go
+++ b/pkg/sdkserver/sdkserver.go
@@ -83,6 +83,10 @@ const (
 // defaultNamespace is the Kubernetes namespace assumed when none is configured.
 const defaultNamespace = "default"
 
+// readHeaderTimeout bounds how long a client may take to send its request
+// headers, so a Slowloris client cannot hold the listener open indefinitely.
+const readHeaderTimeout = 60 * time.Second
+
 var (
 	_ sdk.SDKServer   = &SDKServer{}
 	_ alpha.SDKServer = &SDKServer{}
@@ -172,8 +176,9 @@ func NewSDKServer(gameServerName, namespace string, kubeClient kubernetes.Interf
 		gameServerLister: gameServers.Lister(),
 		gameServerSynced: gameServers.Informer().HasSynced,
 		server: &http.Server{
-			Addr:    fmt.Sprintf(":%d", healthPort),
-			Handler: mux,
+			Addr:              fmt.Sprintf(":%d", healthPort),
+			Handler:           mux,
+			ReadHeaderTimeout: readHeaderTimeout,
 		},
 		clock:              clock.RealClock{},
 		healthMutex:        sync.RWMutex{},
@@ -286,7 +291,7 @@ func (s *SDKServer) Run(ctx context.Context) error {
 	s.logger.Debug("Starting SDKServer http health check...")
 	go func() {
 		if err := s.server.ListenAndServe(); err != nil {
-			if err == http.ErrServerClosed {
+			if errors.Is(err, http.ErrServerClosed) {
 				s.logger.WithError(err).Error("Health check: http server closed")
 			} else {
 				err = errors.Wrap(err, "Could not listen on :8080")
@@ -570,7 +575,7 @@ func (s *SDKServer) Shutdown(_ context.Context, e *sdk.Empty) (*sdk.Empty, error
 func (s *SDKServer) Health(stream sdk.SDK_HealthServer) error {
 	for {
 		_, err := stream.Recv()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			s.logger.Debug("Health stream closed.")
 			return stream.SendAndClose(&sdk.Empty{})
 		}
@@ -1541,10 +1546,9 @@ func (s *SDKServer) updateConnectedPlayers(ctx context.Context) error {
 	}
 
 	gsCopy := gs.DeepCopy()
-	same := false
 	s.gsUpdateMutex.RLock()
 	s.logger.WithField("playerIDs", s.gsConnectedPlayers).Debug("updating connected players")
-	same = apiequality.Semantic.DeepEqual(gsCopy.Status.Players.IDs, s.gsConnectedPlayers)
+	same := apiequality.Semantic.DeepEqual(gsCopy.Status.Players.IDs, s.gsConnectedPlayers)
 	gsCopy.Status.Players.IDs = s.gsConnectedPlayers
 	gsCopy.Status.Players.Count = int64(len(s.gsConnectedPlayers))
 	s.gsUpdateMutex.RUnlock()

--- a/pkg/sdkserver/sdkserver_test.go
+++ b/pkg/sdkserver/sdkserver_test.go
@@ -121,9 +121,9 @@ func TestSidecarRun(t *testing.T) {
 		"label": {
 			f: func(sc *SDKServer, ctx context.Context) {
 				_, err := sc.SetLabel(ctx, &sdk.KeyValue{Key: "foo", Value: "value-foo"})
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				_, err = sc.SetLabel(ctx, &sdk.KeyValue{Key: "bar", Value: "value-bar"})
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 			},
 			expected: expected{
 				labels: map[string]string{
@@ -134,9 +134,9 @@ func TestSidecarRun(t *testing.T) {
 		"annotation": {
 			f: func(sc *SDKServer, ctx context.Context) {
 				_, err := sc.SetAnnotation(ctx, &sdk.KeyValue{Key: "test-1", Value: "annotation-1"})
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				_, err = sc.SetAnnotation(ctx, &sdk.KeyValue{Key: "test-2", Value: "annotation-2"})
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 			},
 			expected: expected{
 				annotations: map[string]string{
@@ -219,7 +219,7 @@ func TestSidecarRun(t *testing.T) {
 			sc.informerFactory.Start(stop)
 			assert.True(t, cache.WaitForCacheSync(stop, sc.gameServerSynced))
 
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			sc.recorder = m.FakeRecorder
 			if v.clock != nil {
 				sc.clock = v.clock
@@ -230,7 +230,7 @@ func TestSidecarRun(t *testing.T) {
 
 			go func() {
 				err := sc.Run(ctx)
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				wg.Done()
 			}()
 			v.f(sc, ctx)
@@ -305,7 +305,7 @@ func TestSDKServerSyncGameServer(t *testing.T) {
 		t.Run(k, func(t *testing.T) {
 			m := agtesting.NewMocks()
 			sc, err := defaultSidecar(m)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			sc.gsState = v.scData.gsState
 			sc.gsLabels = v.scData.gsLabels
@@ -345,7 +345,7 @@ func TestSDKServerSyncGameServer(t *testing.T) {
 			sc.gsWaitForSync.Done()
 
 			err = sc.syncGameServer(ctx, v.key)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.True(t, updated, "should have updated")
 		})
 	}
@@ -407,7 +407,7 @@ func TestSidecarUpdateState(t *testing.T) {
 			sc.gsWaitForSync.Done()
 
 			err = sc.updateState(ctx)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.False(t, updated)
 		})
 	}
@@ -431,7 +431,7 @@ func TestSidecarHealthLastUpdated(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		err := sc.Health(stream)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		wg.Done()
 	}()
 
@@ -440,7 +440,7 @@ func TestSidecarHealthLastUpdated(t *testing.T) {
 	stream.msgs <- &sdk.Empty{}
 
 	err = waitForMessage(sc)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	sc.healthMutex.RLock()
 	assert.Equal(t, sc.clock.Now().UTC().String(), sc.healthLastUpdated.String())
 	sc.healthMutex.RUnlock()
@@ -449,7 +449,7 @@ func TestSidecarHealthLastUpdated(t *testing.T) {
 	fc.Step(3 * time.Second)
 	stream.msgs <- &sdk.Empty{}
 	err = waitForMessage(sc)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	sc.healthMutex.RLock()
 	assert.Equal(t, sc.clock.Now().UTC().String(), sc.healthLastUpdated.String())
 	sc.healthMutex.RUnlock()
@@ -503,7 +503,7 @@ func TestSidecarUnhealthyMessage(t *testing.T) {
 
 	go func() {
 		err := sc.Run(ctx)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	}()
 
 	// manually push through an unhealthy state change
@@ -539,7 +539,7 @@ func TestSidecarHealthy(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		err := sc.Health(stream)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		wg.Done()
 	}()
 
@@ -561,7 +561,7 @@ func TestSidecarHealthy(t *testing.T) {
 			fc.SetTime(time.Now().UTC())
 			stream.msgs <- &sdk.Empty{}
 			err = waitForMessage(sc)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			fc.Step(v.timeAdd)
 			sc.checkHealth()
@@ -606,7 +606,7 @@ func TestSidecarHealthy(t *testing.T) {
 
 		stream.msgs <- &sdk.Empty{}
 		err = waitForMessage(sc)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		fc.Step(10 * time.Second)
 		assert.True(t, sc.healthy())
 	})
@@ -645,7 +645,7 @@ func TestSidecarHTTPHealthCheck(t *testing.T) {
 
 	go func() {
 		err := sc.Run(ctx)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		// gate
 		assert.Equal(t, 1*time.Second, sc.healthTimeout)
 		wg.Done()
@@ -738,7 +738,7 @@ func TestSDKServerWatchGameServer(t *testing.T) {
 	stream := newGameServerMockStream()
 	asyncWatchGameServer(t, sc, stream)
 
-	require.Nil(t, waitConnectedStreamCount(sc, 1))
+	require.NoError(t, waitConnectedStreamCount(sc, 1))
 	require.Equal(t, stream, sc.connectedStreams[0])
 
 	// modify for 2nd event in watch stream
@@ -810,7 +810,7 @@ func TestSDKServerSendGameServerUpdate(t *testing.T) {
 
 	stream := newGameServerMockStream()
 	asyncWatchGameServer(t, sc, stream)
-	assert.Nil(t, waitConnectedStreamCount(sc, 1))
+	assert.NoError(t, waitConnectedStreamCount(sc, 1))
 
 	sc.sendGameServerUpdate(fixture)
 
@@ -873,14 +873,14 @@ func TestSDKServer_SendGameServerUpdateRemovesDisconnectedStream(t *testing.T) {
 	asyncWatchGameServer(t, sc, streamTwo)
 
 	// Verify that two streams are connected.
-	assert.Nil(t, waitConnectedStreamCount(sc, 2))
+	assert.NoError(t, waitConnectedStreamCount(sc, 2))
 	streamOneCancel()
 	streamTwoCancel()
 
 	// Trigger stream removal by sending a game server update.
 	sc.sendGameServerUpdate(fixture)
 	// Verify that zero streams are connected.
-	assert.Nil(t, waitConnectedStreamCount(sc, 0))
+	assert.NoError(t, waitConnectedStreamCount(sc, 0))
 }
 
 func TestSDKServerUpdateEventHandler(t *testing.T) {
@@ -918,7 +918,7 @@ func TestSDKServerUpdateEventHandler(t *testing.T) {
 	}, time.Minute, time.Second, "Could not find the GameServer")
 	stream := newGameServerMockStream()
 	asyncWatchGameServer(t, sc, stream)
-	assert.Nil(t, waitConnectedStreamCount(sc, 1))
+	assert.NoError(t, waitConnectedStreamCount(sc, 1))
 
 	// need to add it before it can be modified
 	fakeWatch.Add(fixture.DeepCopy())
@@ -980,7 +980,7 @@ func TestSDKServerReserveTimeoutOnRun(t *testing.T) {
 
 	go func() {
 		err = sc.Run(ctx)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		wg.Done()
 	}()
 
@@ -1035,7 +1035,7 @@ func TestSDKServerReserveTimeout(t *testing.T) {
 
 	go func() {
 		err = sc.Run(ctx)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		wg.Done()
 	}()
 
@@ -1920,7 +1920,7 @@ func TestDeleteValues(t *testing.T) {
 		"PGFMEopXax": true, "qOOorODUsn": true, "rcVUwlHOME": true}
 
 	newList := deleteValues(list, toDeleteMap)
-	assert.Equal(t, len(list)-len(toDeleteMap), len(newList))
+	assert.Len(t, newList, len(list)-len(toDeleteMap))
 }
 
 func TestSDKServerPlayerCapacity(t *testing.T) {
@@ -2278,7 +2278,7 @@ func TestSDKServerGracefulTerminationInterrupt(t *testing.T) {
 		return true, &agonesv1.GameServerList{Items: []agonesv1.GameServer{*gs.DeepCopy()}}, nil
 	})
 	sc, err := defaultSidecar(m)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	sdkCtx := sc.NewSDKServerContext(ctx)
@@ -2291,7 +2291,7 @@ func TestSDKServerGracefulTerminationInterrupt(t *testing.T) {
 
 	go func() {
 		err := sc.Run(sdkCtx)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		wg.Done()
 	}()
 
@@ -2311,7 +2311,7 @@ func TestSDKServerGracefulTerminationInterrupt(t *testing.T) {
 	cancel()
 	// Assert ctx is cancelled and sdkCtx is not cancelled
 	assertContextCancelled(context.Canceled, 1*time.Second, ctx)
-	assert.Nil(t, sdkCtx.Err())
+	assert.NoError(t, sdkCtx.Err())
 	//	Assert gs is still requestReady
 	assert.Equal(t, agonesv1.GameServerStateRequestReady, sc.gsState)
 	// gs Shutdown
@@ -2344,7 +2344,7 @@ func TestSDKServerGracefulTerminationShutdown(t *testing.T) {
 	})
 
 	sc, err := defaultSidecar(m)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	sdkCtx := sc.NewSDKServerContext(ctx)
@@ -2357,7 +2357,7 @@ func TestSDKServerGracefulTerminationShutdown(t *testing.T) {
 
 	go func() {
 		err = sc.Run(sdkCtx)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		wg.Done()
 	}()
 
@@ -2378,8 +2378,8 @@ func TestSDKServerGracefulTerminationShutdown(t *testing.T) {
 	fakeWatch.Modify(gs.DeepCopy())
 
 	// assert none of the context have been cancelled
-	assert.Nil(t, sdkCtx.Err())
-	assert.Nil(t, ctx.Err())
+	assert.NoError(t, sdkCtx.Err())
+	assert.NoError(t, ctx.Err())
 	//	Mock interruption signal
 	cancel()
 	// Assert ctx is cancelled and sdkCtx is not cancelled
@@ -2409,7 +2409,7 @@ func TestSDKServerGracefulTerminationGameServerStateChannel(t *testing.T) {
 	})
 
 	sc, err := defaultSidecar(m)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -2459,7 +2459,7 @@ func asyncWatchGameServer(t *testing.T, sc *SDKServer, stream sdk.SDK_WatchGameS
 	// if gsWaitForSync is not Done().
 	go func() {
 		err := sc.WatchGameServer(&sdk.Empty{}, stream)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}()
 }
 

--- a/pkg/util/crd/crd_test.go
+++ b/pkg/util/crd/crd_test.go
@@ -46,7 +46,7 @@ func TestWaitForEstablishedCRD(t *testing.T) {
 		})
 
 		err := WaitForEstablishedCRD(context.Background(), extClient.ApiextensionsV1().CustomResourceDefinitions(), "test", logrus.WithField("test", "already-established"))
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	})
 
 	t.Run("CRD takes a second to become established", func(t *testing.T) {
@@ -71,6 +71,6 @@ func TestWaitForEstablishedCRD(t *testing.T) {
 		}()
 
 		err := WaitForEstablishedCRD(context.Background(), extClient.ApiextensionsV1().CustomResourceDefinitions(), "test", logrus.WithField("test", "already-established"))
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	})
 }

--- a/pkg/util/fswatch/fswatch_test.go
+++ b/pkg/util/fswatch/fswatch_test.go
@@ -37,7 +37,7 @@ func TestBatchWatch(t *testing.T) {
 		case eventOut <- struct{}{}:
 			// capacity
 		default:
-			assert.FailNow(t, "second event written - did not want")
+			assert.Fail(t, "second event written - did not want")
 		}
 	}, func(error) {
 		errorCount++

--- a/pkg/util/https/server.go
+++ b/pkg/util/https/server.go
@@ -29,6 +29,10 @@ import (
 
 const (
 	tlsDir = "/certs/"
+
+	// readHeaderTimeout bounds how long a client may take to send its request
+	// headers, so a Slowloris client cannot hold the listener open indefinitely.
+	readHeaderTimeout = 60 * time.Second
 )
 
 // tls is a http server interface to enable easier testing
@@ -80,6 +84,7 @@ func (s *Server) setupServer() {
 		TLSConfig: &cryptotls.Config{
 			GetCertificate: s.getCertificate,
 		},
+		ReadHeaderTimeout: readHeaderTimeout,
 	}
 
 	tlsCert, err := cryptotls.LoadX509KeyPair(tlsDir+"server.crt", tlsDir+"server.key")
@@ -126,6 +131,10 @@ func (s *Server) WatchForCertificateChanges() (func(), error) {
 // Run runs the webhook server, starting a https listener.
 // Will close the http server on stop channel close.
 func (s *Server) Run(ctx context.Context, _ int) error {
+	// context.Background() rather than ctx: ctx is already cancelled by the time
+	// the goroutine wakes, and Shutdown treats a done context as "stop waiting
+	// for in-flight requests and close now", defeating the graceful drain.
+	//nolint:gosec // G118: deliberate, see above.
 	go func() {
 		<-ctx.Done()
 		_ = s.tls.Shutdown(context.Background())
@@ -134,7 +143,7 @@ func (s *Server) Run(ctx context.Context, _ int) error {
 	s.logger.WithField("server", s).Infof("https server started on port :%s", s.port)
 
 	err := s.tls.ListenAndServeTLS(s.certFile, s.keyFile)
-	if err == http.ErrServerClosed {
+	if errors.Is(err, http.ErrServerClosed) {
 		s.logger.WithError(err).Info("https server closed")
 		return nil
 	}

--- a/pkg/util/https/server_test.go
+++ b/pkg/util/https/server_test.go
@@ -49,16 +49,16 @@ func TestServerRun(t *testing.T) {
 	defer cancel()
 
 	err := s.Run(ctx, 0)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	client := ts.server.Client()
 	resp, err := client.Get(ts.server.URL + "/test")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer resp.Body.Close() // nolint: errcheck
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 
 	resp, err = client.Get(ts.server.URL + "/")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer resp.Body.Close() // nolint: errcheck
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }

--- a/pkg/util/httpserver/server.go
+++ b/pkg/util/httpserver/server.go
@@ -19,11 +19,16 @@ package httpserver
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"agones.dev/agones/pkg/util/runtime"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
+
+// readHeaderTimeout bounds how long a client may take to send its request
+// headers, so a Slowloris client cannot hold the listener open indefinitely.
+const readHeaderTimeout = 60 * time.Second
 
 // Server is a HTTPs server that conforms to the runner interface
 // we use in /cmd/controller.
@@ -43,9 +48,14 @@ func (s *Server) Run(ctx context.Context, _ int) error {
 		s.Port = "8080"
 	}
 	srv := &http.Server{
-		Addr:    ":" + s.Port,
-		Handler: s,
+		Addr:              ":" + s.Port,
+		Handler:           s,
+		ReadHeaderTimeout: readHeaderTimeout,
 	}
+	// context.Background() rather than ctx: ctx is already cancelled by the time
+	// the goroutine wakes, and Shutdown treats a done context as "stop waiting
+	// for in-flight requests and close now", defeating the graceful drain.
+	//nolint:gosec // G118: deliberate, see above.
 	go func() {
 		<-ctx.Done()
 		_ = srv.Shutdown(context.Background())

--- a/pkg/util/runtime/runtime_test.go
+++ b/pkg/util/runtime/runtime_test.go
@@ -18,6 +18,7 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -26,22 +27,25 @@ import (
 )
 
 func TestHandleError(t *testing.T) {
+	// apimachinery's ErrorHandlers is a package-level slice and the only seam
+	// for observing what HandleError forwards, so swap it out and restore it.
 	old := runtime.ErrorHandlers
-	defer func() { runtime.ErrorHandlers = old }()
+	defer func() { runtime.ErrorHandlers = old }() //nolint:reassign // restoring the swap below.
 	var result error
+	//nolint:reassign // deliberate test seam, restored by the defer above.
 	runtime.ErrorHandlers = []runtime.ErrorHandler{
 		func(_ context.Context, err error, _ string, _ ...interface{}) {
 			result = err
 		},
 	}
 	HandleError(nil, nil)
-	assert.Nil(t, result, "No Errors for now")
+	assert.NoError(t, result, "No Errors for now")
 
 	err := fmt.Errorf("test")
 	// test nil logger
 	logger := NewLoggerWithSource("test")
 	HandleError(logger.WithError(err), err)
-	if result != err {
+	if !errors.Is(result, err) {
 		t.Errorf("did not receive custom handler")
 	}
 }

--- a/pkg/util/webhooks/webhooks_test.go
+++ b/pkg/util/webhooks/webhooks_test.go
@@ -113,13 +113,13 @@ func TestWebHookAddHandler(t *testing.T) {
 
 			buf := &bytes.Buffer{}
 			err := json.NewEncoder(buf).Encode(fixture)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			r, err := http.NewRequest("GET", url, buf)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			resp, err := client.Do(r)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			defer resp.Body.Close() // nolint: errcheck
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
 
@@ -193,7 +193,7 @@ func TestWebHookFleetValidationHandler(t *testing.T) {
 					callCount++
 					obj := review.Request.Object
 					err := json.Unmarshal(obj.Raw, fleet)
-					assert.NotNil(t, err)
+					assert.Error(t, err)
 					if err != nil {
 						return review, errors.Wrapf(err, "error unmarshalling original Fleet json: %s", obj.Raw)
 					}
@@ -209,17 +209,17 @@ func TestWebHookFleetValidationHandler(t *testing.T) {
 
 			buf := &bytes.Buffer{}
 			err := json.NewEncoder(buf).Encode(fixture)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			r, err := http.NewRequest("GET", url, buf)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			resp, err := client.Do(r)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			defer resp.Body.Close() // nolint: errcheck
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
 			body, err := io.ReadAll(resp.Body)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			expected := "cannot unmarshal bool into Go struct field Container.spec.template.spec.template.spec.containers.name of type string"
 			assert.Contains(t, string(body), expected)

--- a/pkg/util/workerqueue/workerqueue.go
+++ b/pkg/util/workerqueue/workerqueue.go
@@ -58,9 +58,8 @@ func (l *traceError) Error() string {
 
 // isTraceError returns if the error is a trace error or not
 func isTraceError(err error) bool {
-	cause := errors.Cause(err)
-	_, ok := cause.(*traceError)
-	return ok
+	var traceErr *traceError
+	return errors.As(err, &traceErr)
 }
 
 // Handler is the handler for processing the work queue

--- a/pkg/util/workerqueue/workerqueue_test.go
+++ b/pkg/util/workerqueue/workerqueue_test.go
@@ -86,7 +86,7 @@ func TestWorkerQueueHealthy(t *testing.T) {
 
 		return false, nil
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	close(done) // Ensure the handler no longer blocks.
 	cancel()    // Stop the worker queue.
@@ -100,7 +100,7 @@ func TestWorkerQueueHealthy(t *testing.T) {
 
 		return false, nil
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestWorkQueueHealthCheck(t *testing.T) {
@@ -126,13 +126,13 @@ func TestWorkQueueHealthCheck(t *testing.T) {
 		logrus.WithField("runcount", rc).Info("Checking run count before liveness check")
 		return rc == workersCount, nil
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	f := func(t *testing.T, url string, status int) {
 		// sometimes the http server takes a bit to start up
 		err := wait.PollUntilContextTimeout(context.Background(), time.Second, 5*time.Second, true, func(_ context.Context) (done bool, err error) {
 			resp, err := http.Get(url)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			defer resp.Body.Close() // nolint: errcheck
 
 			if status != resp.StatusCode {
@@ -140,14 +140,14 @@ func TestWorkQueueHealthCheck(t *testing.T) {
 			}
 
 			body, err := io.ReadAll(resp.Body)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, status, resp.StatusCode)
 			assert.Equal(t, []byte("{}\n"), body)
 
 			return true, nil
 		})
 
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	}
 
 	url := server.URL + "/live"
@@ -160,7 +160,7 @@ func TestWorkQueueHealthCheck(t *testing.T) {
 		logrus.WithField("runcount", rc).Info("Checking run count")
 		return rc == 0, nil
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// gate
 	assert.Error(t, wq.Healthy())

--- a/sdks/go/sdk.go
+++ b/sdks/go/sdk.go
@@ -164,7 +164,7 @@ func (s *SDK) WatchGameServer(f GameServerCallback) error {
 			var gs *sdk.GameServer
 			gs, err = stream.Recv()
 			if err != nil {
-				if err == io.EOF {
+				if errors.Is(err, io.EOF) {
 					log(gs, "gameserver event stream EOF received", nil)
 					return
 				}

--- a/sdks/go/sdk_test.go
+++ b/sdks/go/sdk_test.go
@@ -42,7 +42,7 @@ func TestSDK(t *testing.T) {
 	assert.False(t, sm.hm.healthy)
 
 	err := s.Ready()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, sm.ready)
 	assert.False(t, sm.shutdown)
 
@@ -51,7 +51,7 @@ func TestSDK(t *testing.T) {
 	assert.EqualValues(t, 12, sm.reserved.Seconds)
 
 	err = s.Health()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, sm.hm.healthy)
 
 	err = s.Allocate()
@@ -59,12 +59,12 @@ func TestSDK(t *testing.T) {
 	assert.True(t, sm.allocated)
 
 	err = s.Shutdown()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, sm.ready)
 	assert.True(t, sm.shutdown)
 
 	gs, err := s.GameServer()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, gs)
 }
 
@@ -85,7 +85,7 @@ func TestSDKWatchGameServer(t *testing.T) {
 		assert.Equal(t, fixture.ObjectMeta.Name, gs.ObjectMeta.Name)
 		updated <- struct{}{}
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	sm.wm.msgs <- fixture
 
@@ -108,7 +108,7 @@ func TestSDKSetLabel(t *testing.T) {
 
 	expected := "bar"
 	err := s.SetLabel("foo", expected)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, expected, sm.labels["agones.dev/sdk-foo"])
 }
 
@@ -124,7 +124,7 @@ func TestSDKSetAnnotation(t *testing.T) {
 
 	expected := "bar"
 	err := s.SetAnnotation("foo", expected)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, expected, sm.annotations["agones.dev/sdk-foo"])
 }
 

--- a/test/e2e/allocator_test.go
+++ b/test/e2e/allocator_test.go
@@ -200,8 +200,8 @@ func TestAllocatorWithMatchExpressions(t *testing.T) {
 		response, err := grpcClient.Allocate(ctx, request)
 		require.NoError(c, err, "failing Allocate request")
 		helper.ValidateAllocatorResponse(t, response)
-		require.Equal(t, response.Metadata.Labels["tier"], "staging")
-		require.Equal(t, response.Metadata.Labels["gslabel"], "allocatedbytest")
+		require.Equal(t, "staging", response.Metadata.Labels["tier"])
+		require.Equal(t, "allocatedbytest", response.Metadata.Labels["gslabel"])
 
 		// Attempt allocation with NotIn on the same label value — should find no match.
 		noMatchRequest := &pb.AllocationRequest{
@@ -229,7 +229,7 @@ func TestRestAllocatorWithDeprecatedRequired(t *testing.T) {
 	tlsCA := helper.RefreshAllocatorTLSCerts(ctx, t, ip, framework)
 
 	flt, err := helper.CreateFleet(ctx, framework.Namespace, framework)
-	if !assert.Nil(t, err) {
+	if !assert.NoError(t, err) {
 		return
 	}
 	framework.AssertFleetCondition(t, flt, e2e.FleetReadyCount(flt.Spec.Replicas))
@@ -243,7 +243,7 @@ func TestRestAllocatorWithDeprecatedRequired(t *testing.T) {
 		Metadata:                     &pb.MetaPatch{Labels: map[string]string{"gslabel": "allocatedbytest"}},
 	}
 	tlsCfg, err := helper.GetTLSConfig(ctx, allocatorClientSecretNamespace, allocatorClientSecretName, tlsCA, framework)
-	if !assert.Nil(t, err) {
+	if !assert.NoError(t, err) {
 		return
 	}
 	client := &http.Client{
@@ -252,11 +252,11 @@ func TestRestAllocatorWithDeprecatedRequired(t *testing.T) {
 		},
 	}
 	jsonRes, err := json.Marshal(request)
-	if !assert.Nil(t, err) {
+	if !assert.NoError(t, err) {
 		return
 	}
 	req, err := http.NewRequest("POST", "https://"+requestURL+"/gameserverallocation", bytes.NewBuffer(jsonRes))
-	if !assert.Nil(t, err) {
+	if !assert.NoError(t, err) {
 		logrus.WithError(err).Info("failed to create rest request")
 		return
 	}
@@ -361,8 +361,8 @@ func TestAllocatorWithCountersAndLists(t *testing.T) {
 		assert.Equal(c, int64(1), response.GetCounters()["players"].Count.GetValue())
 		assert.Contains(c, response.GetLists(), "rooms")
 		assert.Equal(c, int64(10), response.GetLists()["rooms"].Capacity.GetValue())
-		assert.EqualValues(c, request.Lists["rooms"].AddValues, response.GetLists()["rooms"].Values)
-		assert.NotEqualValues(c, request.Lists["rooms"].DeleteValues, response.GetLists()["rooms"].Values)
+		assert.Equal(c, request.Lists["rooms"].AddValues, response.GetLists()["rooms"].Values)
+		assert.NotEqual(c, request.Lists["rooms"].DeleteValues, response.GetLists()["rooms"].Values)
 	}, 5*time.Minute, 2*time.Second)
 }
 
@@ -426,7 +426,7 @@ func TestRestAllocatorWithCountersAndLists(t *testing.T) {
 	}
 	err = wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
 		tlsCfg, err := helper.GetTLSConfig(ctx, allocatorClientSecretNamespace, allocatorClientSecretName, tlsCA, framework)
-		if !assert.Nil(t, err) {
+		if !assert.NoError(t, err) {
 			return false, err
 		}
 		client := &http.Client{
@@ -435,11 +435,11 @@ func TestRestAllocatorWithCountersAndLists(t *testing.T) {
 			},
 		}
 		jsonRes, err := protojson.Marshal(request)
-		if !assert.Nil(t, err) {
+		if !assert.NoError(t, err) {
 			return false, nil
 		}
 		req, err := http.NewRequest("POST", "https://"+requestURL+"/gameserverallocation", bytes.NewBuffer(jsonRes))
-		if !assert.Nil(t, err) {
+		if !assert.NoError(t, err) {
 			return false, nil
 		}
 		resp, err := client.Do(req)
@@ -491,7 +491,7 @@ func TestRestAllocatorWithSelectors(t *testing.T) {
 		Metadata:            &pb.MetaPatch{Labels: map[string]string{"gslabel": "allocatedbytest", "blue-frog.fred_thing": "test.dog_fred-blue"}},
 	}
 	tlsCfg, err := helper.GetTLSConfig(ctx, allocatorClientSecretNamespace, allocatorClientSecretName, tlsCA, framework)
-	if !assert.Nil(t, err) {
+	if !assert.NoError(t, err) {
 		return
 	}
 	client := &http.Client{
@@ -500,11 +500,11 @@ func TestRestAllocatorWithSelectors(t *testing.T) {
 		},
 	}
 	jsonRes, err := json.Marshal(request)
-	if !assert.Nil(t, err) {
+	if !assert.NoError(t, err) {
 		return
 	}
 	req, err := http.NewRequest("POST", "https://"+requestURL+"/gameserverallocation", bytes.NewBuffer(jsonRes))
-	if !assert.Nil(t, err) {
+	if !assert.NoError(t, err) {
 		logrus.WithError(err).Info("failed to create rest request")
 		return
 	}
@@ -556,7 +556,7 @@ func TestAllocatorCrossNamespace(t *testing.T) {
 
 	namespaceB := fmt.Sprintf("allocator-b-%s", uuid.NewUUID())
 	err := framework.CreateNamespace(namespaceB)
-	if !assert.Nil(t, err) {
+	if !assert.NoError(t, err) {
 		return
 	}
 	defer func() {
@@ -586,7 +586,7 @@ func TestAllocatorCrossNamespace(t *testing.T) {
 
 	// Create a fleet in namespace B. Allocation should not happen in A according to policy
 	flt, err := helper.CreateFleet(ctx, namespaceB, framework)
-	if !assert.Nil(t, err) {
+	if !assert.NoError(t, err) {
 		return
 	}
 	framework.AssertFleetCondition(t, flt, e2e.FleetReadyCount(flt.Spec.Replicas))

--- a/test/e2e/allochelper/helper_func.go
+++ b/test/e2e/allochelper/helper_func.go
@@ -104,13 +104,13 @@ func CreateAllocationPolicy(ctx context.Context, t *testing.T, framework *e2e.Fr
 func GetAllocatorEndpoint(ctx context.Context, t *testing.T, framework *e2e.Framework) (string, int32) {
 	kubeCore := framework.KubeClient.CoreV1()
 	svc, err := kubeCore.Services(agonesSystemNamespace).Get(ctx, allocatorServiceName, metav1.GetOptions{})
-	if !assert.Nil(t, err) {
+	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
 	if !assert.NotNil(t, svc.Status.LoadBalancer) {
 		t.FailNow()
 	}
-	if !assert.Equal(t, 1, len(svc.Status.LoadBalancer.Ingress)) {
+	if !assert.Len(t, svc.Status.LoadBalancer.Ingress, 1) {
 		t.FailNow()
 	}
 	if !assert.NotNil(t, 0, svc.Status.LoadBalancer.Ingress[0].IP) {
@@ -276,7 +276,7 @@ func ValidateAllocatorResponse(t *testing.T, resp *pb.AllocationResponse) {
 	if !assert.NotNil(t, resp) {
 		return
 	}
-	assert.Greater(t, len(resp.Ports), 0)
+	assert.NotEmpty(t, resp.Ports)
 	assert.NotEmpty(t, resp.GameServerName)
 	assert.NotEmpty(t, resp.Address)
 	assert.NotEmpty(t, resp.Addresses)
@@ -303,7 +303,7 @@ func GetAllocatorClient(ctx context.Context, t *testing.T, framework *e2e.Framew
 	tlsCA := RefreshAllocatorTLSCerts(ctx, t, ip, framework)
 
 	flt, err := CreateFleet(ctx, framework.Namespace, framework)
-	if !assert.Nil(t, err) {
+	if !assert.NoError(t, err) {
 		return nil, err
 	}
 	framework.AssertFleetCondition(t, flt, e2e.FleetReadyCount(flt.Spec.Replicas))

--- a/test/e2e/fleet_test.go
+++ b/test/e2e/fleet_test.go
@@ -16,6 +16,7 @@ package e2e
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -101,8 +102,9 @@ func TestFleetStrategyValidation(t *testing.T) {
 	assert.NoError(t, err)
 	// func to check that we receive an expected error
 	verifyErr := func(err error) {
-		assert.NotNil(t, err)
-		statusErr, ok := err.(*k8serrors.StatusError)
+		assert.Error(t, err)
+		var statusErr *k8serrors.StatusError
+		ok := errors.As(err, &statusErr)
 		assert.True(t, ok)
 		fmt.Println(statusErr)
 		assert.Len(t, statusErr.Status().Details.Causes, 1)
@@ -912,8 +914,9 @@ func TestFleetGSSpecValidation(t *testing.T) {
 		}
 	flt.Spec.Template.Spec.Container = "testing"
 	_, err := client.Fleets(framework.Namespace).Create(ctx, flt, metav1.CreateOptions{})
-	assert.NotNil(t, err)
-	statusErr, ok := err.(*k8serrors.StatusError)
+	assert.Error(t, err)
+	var statusErr *k8serrors.StatusError
+	ok := errors.As(err, &statusErr)
 	assert.True(t, ok)
 
 	assert.Len(t, statusErr.Status().Details.Causes, 2)
@@ -924,8 +927,8 @@ func TestFleetGSSpecValidation(t *testing.T) {
 
 	flt.Spec.Template.Spec.Container = ""
 	_, err = client.Fleets(framework.Namespace).Create(ctx, flt, metav1.CreateOptions{})
-	assert.NotNil(t, err)
-	statusErr, ok = err.(*k8serrors.StatusError)
+	assert.Error(t, err)
+	ok = errors.As(err, &statusErr)
 	assert.True(t, ok)
 	if assert.Len(t, statusErr.Status().Details.Causes, 2) {
 		assert.Equal(t, metav1.CauseTypeFieldValueInvalid, statusErr.Status().Details.Causes[1].Type)
@@ -946,8 +949,8 @@ func TestFleetGSSpecValidation(t *testing.T) {
 	fltPort.Spec.Template.Spec.Ports = []agonesv1.GameServerPort{{Name: "Dyn", HostPort: 5555, PortPolicy: agonesv1.Dynamic, ContainerPort: 5555}}
 
 	_, err = client.Fleets(framework.Namespace).Create(ctx, fltPort, metav1.CreateOptions{})
-	assert.NotNil(t, err)
-	statusErr, ok = err.(*k8serrors.StatusError)
+	assert.Error(t, err)
+	ok = errors.As(err, &statusErr)
 	assert.True(t, ok)
 	assert.Len(t, statusErr.Status().Details.Causes, 1)
 	assert.Contains(t, statusErr.Status().Details.Causes[0].Message, agonesv1.ErrHostPort)
@@ -969,9 +972,10 @@ func TestFleetNameValidation(t *testing.T) {
 	nameLen := validation.LabelValueMaxLength + 1
 	flt.Name = strings.Repeat("f", nameLen)
 	_, err := client.Fleets(framework.Namespace).Create(ctx, flt, metav1.CreateOptions{})
-	require.NotNil(t, err)
-	statusErr := err.(*k8serrors.StatusError)
-	assert.True(t, len(statusErr.Status().Details.Causes) > 0)
+	require.Error(t, err)
+	var statusErr *k8serrors.StatusError
+	require.ErrorAs(t, err, &statusErr)
+	assert.NotEmpty(t, statusErr.Status().Details.Causes)
 	assert.Equal(t, metav1.CauseType("FieldValueTooLong"), statusErr.Status().Details.Causes[0].Type)
 	goodFlt := defaultFleet(framework.Namespace)
 	goodFlt.Name = flt.Name[0 : nameLen-1]
@@ -1329,7 +1333,8 @@ func TestFleetWithLongLabelsAnnotations(t *testing.T) {
 	flt.Spec.Template.ObjectMeta.Labels["label"] = longName
 	_, err := client.Fleets(framework.Namespace).Create(ctx, flt, metav1.CreateOptions{})
 	assert.Error(t, err)
-	statusErr, ok := err.(*k8serrors.StatusError)
+	var statusErr *k8serrors.StatusError
+	ok := errors.As(err, &statusErr)
 	assert.True(t, ok)
 	assert.Len(t, statusErr.Status().Details.Causes, 1)
 	assert.Equal(t, metav1.CauseTypeFieldValueInvalid, statusErr.Status().Details.Causes[0].Type)
@@ -1341,7 +1346,7 @@ func TestFleetWithLongLabelsAnnotations(t *testing.T) {
 	flt.Spec.Template.ObjectMeta.Annotations[longName] = normalLengthName
 	_, err = client.Fleets(framework.Namespace).Create(ctx, flt, metav1.CreateOptions{})
 	assert.Error(t, err)
-	statusErr, ok = err.(*k8serrors.StatusError)
+	ok = errors.As(err, &statusErr)
 	assert.True(t, ok)
 	assert.Len(t, statusErr.Status().Details.Causes, 1)
 	assert.Equal(t, "spec.template.metadata.annotations", statusErr.Status().Details.Causes[0].Field)
@@ -1364,7 +1369,7 @@ func TestFleetWithLongLabelsAnnotations(t *testing.T) {
 	goodFlt.Spec.Template.ObjectMeta.Annotations[longName] = normalLengthName
 	_, err = client.Fleets(framework.Namespace).Update(ctx, goodFlt, metav1.UpdateOptions{})
 	assert.Error(t, err)
-	statusErr, ok = err.(*k8serrors.StatusError)
+	ok = errors.As(err, &statusErr)
 	assert.True(t, ok)
 	require.Len(t, statusErr.Status().Details.Causes, 1)
 	assert.Equal(t, "spec.template.metadata.annotations", statusErr.Status().Details.Causes[0].Field)
@@ -1518,8 +1523,9 @@ func TestFleetResourceValidation(t *testing.T) {
 	containers[1].Resources.Requests[corev1.ResourceMemory] = mi128
 
 	_, err := client.Fleets(framework.Namespace).Create(ctx, flt.DeepCopy(), metav1.CreateOptions{})
-	assert.NotNil(t, err)
-	statusErr, ok := err.(*k8serrors.StatusError)
+	assert.Error(t, err)
+	var statusErr *k8serrors.StatusError
+	ok := errors.As(err, &statusErr)
 	assert.True(t, ok)
 	assert.Len(t, statusErr.Status().Details.Causes, 1)
 	assert.Equal(t, metav1.CauseTypeFieldValueInvalid, statusErr.Status().Details.Causes[0].Type)
@@ -1527,8 +1533,8 @@ func TestFleetResourceValidation(t *testing.T) {
 
 	containers[0].Resources.Limits[corev1.ResourceCPU] = resource.MustParse("-50m")
 	_, err = client.Fleets(framework.Namespace).Create(ctx, flt.DeepCopy(), metav1.CreateOptions{})
-	assert.NotNil(t, err)
-	statusErr, ok = err.(*k8serrors.StatusError)
+	assert.Error(t, err)
+	ok = errors.As(err, &statusErr)
 	assert.True(t, ok)
 
 	assert.Len(t, statusErr.Status().Details.Causes, 3)

--- a/test/e2e/fleetautoscaler_test.go
+++ b/test/e2e/fleetautoscaler_test.go
@@ -71,7 +71,7 @@ func TestAutoscalerBasicFunctions(t *testing.T) {
 	stable := framework.AgonesClient.AgonesV1()
 	fleets := stable.Fleets(framework.Namespace)
 	flt, err := fleets.Create(ctx, defaultFleet(framework.Namespace), metav1.CreateOptions{})
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		defer fleets.Delete(ctx, flt.ObjectMeta.Name, metav1.DeleteOptions{}) // nolint:errcheck
 	}
 
@@ -89,14 +89,14 @@ func TestAutoscalerBasicFunctions(t *testing.T) {
 
 	// patch the autoscaler to increase MinReplicas and watch the fleet scale up
 	fas, err = patchFleetAutoscaler(ctx, fas, intstr.FromInt(int(bufferSize)), bufferSize+2, fas.Spec.Policy.Buffer.MaxReplicas)
-	assert.Nil(t, err, "could not patch fleetautoscaler")
+	assert.NoError(t, err, "could not patch fleetautoscaler")
 
 	// min replicas is now higher than buffer size, will scale to that level
 	framework.AssertFleetCondition(t, flt, e2e.FleetReadyCount(fas.Spec.Policy.Buffer.MinReplicas))
 
 	// patch the autoscaler to remove MinReplicas and watch the fleet scale down to bufferSize
 	fas, err = patchFleetAutoscaler(ctx, fas, intstr.FromInt(int(bufferSize)), 0, fas.Spec.Policy.Buffer.MaxReplicas)
-	assert.Nil(t, err, "could not patch fleetautoscaler")
+	assert.NoError(t, err, "could not patch fleetautoscaler")
 
 	bufferSize = int32(fas.Spec.Policy.Buffer.BufferSize.IntValue())
 	framework.AssertFleetCondition(t, flt, e2e.FleetReadyCount(bufferSize))
@@ -153,7 +153,7 @@ func TestFleetAutoscalerDefaultSyncInterval(t *testing.T) {
 	stable := framework.AgonesClient.AgonesV1()
 	fleets := stable.Fleets(framework.Namespace)
 	flt, err := fleets.Create(ctx, defaultFleet(framework.Namespace), metav1.CreateOptions{})
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		defer fleets.Delete(ctx, flt.ObjectMeta.Name, metav1.DeleteOptions{}) // nolint:errcheck
 	}
 
@@ -178,7 +178,7 @@ func TestFleetAutoscalerDefaultSyncInterval(t *testing.T) {
 		},
 	}
 	fas, err := fleetautoscalers.Create(ctx, defaultFas, metav1.CreateOptions{})
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		defer fleetautoscalers.Delete(ctx, fas.ObjectMeta.Name, metav1.DeleteOptions{}) // nolint:errcheck
 	} else {
 		// if we could not create the autoscaler, their is no point going further
@@ -254,7 +254,7 @@ func TestFleetAutoScalerRollingUpdate(t *testing.T) {
 		gssList, err := framework.AgonesClient.AgonesV1().GameServerSets(framework.Namespace).List(ctx,
 			metav1.ListOptions{LabelSelector: selector.String()})
 		require.NoError(c, err)
-		require.Equal(c, 2, len(gssList.Items))
+		require.Len(c, gssList.Items, 2)
 	}, 30*time.Second, 1*time.Second)
 
 	// Check that total number of gameservers in the system does not go lower than RollingUpdate
@@ -271,7 +271,7 @@ func TestFleetAutoScalerRollingUpdate(t *testing.T) {
 		gssList, err := framework.AgonesClient.AgonesV1().GameServerSets(framework.Namespace).List(ctx,
 			metav1.ListOptions{LabelSelector: selector.String()})
 		require.NoError(c, err)
-		require.Equal(c, 1, len(gssList.Items))
+		require.Len(c, gssList.Items, 1)
 
 	}, 5*time.Minute, 1*time.Second)
 }
@@ -287,7 +287,7 @@ func TestAutoscalerStressCreate(t *testing.T) {
 	alpha1 := framework.AgonesClient.AgonesV1()
 	fleets := alpha1.Fleets(framework.Namespace)
 	flt, err := fleets.Create(ctx, defaultFleet(framework.Namespace), metav1.CreateOptions{})
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		defer fleets.Delete(ctx, flt.ObjectMeta.Name, metav1.DeleteOptions{}) // nolint:errcheck
 	}
 
@@ -321,10 +321,7 @@ func TestAutoscalerStressCreate(t *testing.T) {
 				log.WithField("fas", fas.ObjectMeta.Name).Info("Created!")
 				defer fleetautoscalers.Delete(ctx, fas.ObjectMeta.Name, metav1.DeleteOptions{}) // nolint:errcheck
 				require.True(t, valid,
-					fmt.Sprintf("FleetAutoscaler created even if the parameters are NOT valid: %d %d %d",
-						bufferSize,
-						fas.Spec.Policy.Buffer.MinReplicas,
-						fas.Spec.Policy.Buffer.MaxReplicas))
+					"FleetAutoscaler created even if the parameters are NOT valid: %d %d %d", bufferSize, fas.Spec.Policy.Buffer.MinReplicas, fas.Spec.Policy.Buffer.MaxReplicas)
 
 				expectedReplicas := bufferSize
 				if expectedReplicas < fas.Spec.Policy.Buffer.MinReplicas {
@@ -337,10 +334,7 @@ func TestAutoscalerStressCreate(t *testing.T) {
 				framework.AssertFleetCondition(t, flt, e2e.FleetReadyCount(expectedReplicas))
 			} else {
 				require.False(t, valid,
-					fmt.Sprintf("FleetAutoscaler NOT created even if the parameters are valid: %d %d %d (%s)",
-						bufferSize,
-						minReplicas,
-						maxReplicas, err))
+					"FleetAutoscaler NOT created even if the parameters are valid: %d %d %d (%s)", bufferSize, minReplicas, maxReplicas, err)
 			}
 		}()
 	}
@@ -531,7 +525,7 @@ func TestFleetAutoscalerTLSWebhook(t *testing.T) {
 
 	secrets := framework.KubeClient.CoreV1().Secrets(defaultNS)
 	secr, err = secrets.Create(ctx, secr.DeepCopy(), metav1.CreateOptions{})
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		defer secrets.Delete(ctx, secr.ObjectMeta.Name, metav1.DeleteOptions{}) // nolint:errcheck
 	}
 
@@ -550,7 +544,7 @@ func TestFleetAutoscalerTLSWebhook(t *testing.T) {
 		MountPath: "/home/service/certs",
 	}}
 	pod, err = framework.KubeClient.CoreV1().Pods(defaultNS).Create(ctx, pod.DeepCopy(), metav1.CreateOptions{})
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		defer framework.KubeClient.CoreV1().Pods(defaultNS).Delete(ctx, pod.ObjectMeta.Name, metav1.DeleteOptions{}) // nolint:errcheck
 	} else {
 		// if we could not create the webhook, there is no point going further
@@ -568,10 +562,10 @@ func TestFleetAutoscalerTLSWebhook(t *testing.T) {
 		_, err := framework.KubeClient.CoreV1().Services(defaultNS).Get(ctx, svc.ObjectMeta.Name, metav1.GetOptions{})
 		return k8serrors.IsNotFound(err), nil
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	svc, err = framework.KubeClient.CoreV1().Services(defaultNS).Create(ctx, svc.DeepCopy(), metav1.CreateOptions{})
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		defer framework.KubeClient.CoreV1().Services(defaultNS).Delete(ctx, svc.ObjectMeta.Name, metav1.DeleteOptions{}) // nolint:errcheck
 	} else {
 		// if we could not create the service, there is no point going further
@@ -584,7 +578,7 @@ func TestFleetAutoscalerTLSWebhook(t *testing.T) {
 	initialReplicasCount := int32(1)
 	flt.Spec.Replicas = initialReplicasCount
 	flt, err = fleets.Create(ctx, flt.DeepCopy(), metav1.CreateOptions{})
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		defer fleets.Delete(ctx, flt.ObjectMeta.Name, metav1.DeleteOptions{}) // nolint:errcheck
 	}
 
@@ -605,7 +599,7 @@ func TestFleetAutoscalerTLSWebhook(t *testing.T) {
 		CABundle: caPem,
 	}
 	fas, err = fleetautoscalers.Create(ctx, fas.DeepCopy(), metav1.CreateOptions{})
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		defer fleetautoscalers.Delete(ctx, fas.ObjectMeta.Name, metav1.DeleteOptions{}) // nolint:errcheck
 	} else {
 		// if we could not create the autoscaler, their is no point going further
@@ -2344,7 +2338,7 @@ func nextCronMinuteBetween(currentTime time.Time) string {
 // Parse a duration string and return a duration struct
 func mustParseDuration(t *testing.T, duration string) time.Duration {
 	d, err := time.ParseDuration(duration)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	return d
 }
 

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -35,6 +35,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -228,7 +229,7 @@ func (f *Framework) CreateGameServerAndWaitUntilReady(t *testing.T, ns string, g
 	log := TestLogger(t)
 	newGs, err := f.AgonesClient.AgonesV1().GameServers(ns).Create(context.Background(), gs, metav1.CreateOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("creating %v GameServer instances failed (%v): %v", gs.Spec, gs.Name, err)
+		return nil, fmt.Errorf("creating %v GameServer instances failed (%v): %w", gs.Spec, gs.Name, err)
 	}
 
 	log.WithField("gs", newGs.ObjectMeta.Name).Info("GameServer created, waiting for Ready")
@@ -236,7 +237,7 @@ func (f *Framework) CreateGameServerAndWaitUntilReady(t *testing.T, ns string, g
 	readyGs, err := f.WaitForGameServerState(t, newGs, agonesv1.GameServerStateReady, f.WaitForState)
 
 	if err != nil {
-		return readyGs, fmt.Errorf("waiting for %v GameServer instance readiness timed out (%v): %v",
+		return readyGs, fmt.Errorf("waiting for %v GameServer instance readiness timed out (%v): %w",
 			gs.Spec, gs.Name, err)
 	}
 
@@ -315,7 +316,7 @@ func (f *Framework) CycleAllocations(ctx context.Context, t *testing.T, flt *ago
 		go func(gsa *allocationv1.GameServerAllocation) {
 			time.Sleep(allocDuration)
 			err := f.AgonesClient.AgonesV1().GameServers(gsa.Namespace).Delete(context.Background(), gsa.Status.GameServerName, metav1.DeleteOptions{})
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		}(gsa)
 
 		return false, nil

--- a/test/e2e/gameserver_test.go
+++ b/test/e2e/gameserver_test.go
@@ -17,6 +17,7 @@ package e2e
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -61,13 +62,13 @@ func TestCreateConnect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Could not get a GameServer ready: %v", err)
 	}
-	assert.Equal(t, len(readyGs.Status.Ports), 1)
+	assert.Len(t, readyGs.Status.Ports, 1)
 	assert.NotEmpty(t, readyGs.Status.Ports[0].Port)
 	assert.NotEmpty(t, readyGs.Status.Address)
 	assert.NotEmpty(t, readyGs.Status.Addresses)
 
 	require.NotEmpty(t, readyGs.Status.NodeName)
-	require.Equal(t, readyGs.Status.State, agonesv1.GameServerStateReady)
+	require.Equal(t, agonesv1.GameServerStateReady, readyGs.Status.State)
 
 	// check connectivity before anything else.
 	reply, err := framework.SendGameServerUDP(t, readyGs, "Hello World !")
@@ -147,7 +148,7 @@ func TestSDKSetLabel(t *testing.T) {
 		t.Fatalf("Could not get a GameServer ready: %v", err)
 	}
 
-	assert.Equal(t, readyGs.Status.State, agonesv1.GameServerStateReady)
+	assert.Equal(t, agonesv1.GameServerStateReady, readyGs.Status.State)
 	reply, err := framework.SendGameServerUDP(t, readyGs, "LABEL")
 	if err != nil {
 		t.Fatalf("Could ping GameServer: %v", err)
@@ -212,7 +213,7 @@ func TestSDKSetAnnotation(t *testing.T) {
 	}
 	defer framework.AgonesClient.AgonesV1().GameServers(framework.Namespace).Delete(ctx, readyGs.ObjectMeta.Name, metav1.DeleteOptions{}) // nolint: errcheck
 
-	assert.Equal(t, readyGs.Status.State, agonesv1.GameServerStateReady)
+	assert.Equal(t, agonesv1.GameServerStateReady, readyGs.Status.State)
 	reply, err := framework.SendGameServerUDP(t, readyGs, "ANNOTATION")
 	if err != nil {
 		t.Fatalf("Could ping GameServer: %v", err)
@@ -233,7 +234,7 @@ func TestSDKSetAnnotation(t *testing.T) {
 
 	logrus.WithField("annotations", gs.ObjectMeta.Annotations).Info("annotation information")
 
-	if !assert.Nil(t, err) {
+	if !assert.NoError(t, err) {
 		assert.FailNow(t, "error waiting on annotation to be set")
 	}
 	assert.NotEmpty(t, gs.ObjectMeta.Annotations[annotation])
@@ -272,7 +273,7 @@ func TestUnhealthyGameServersWithoutFreePorts(t *testing.T) {
 	if err != nil {
 		assert.FailNow(t, "Failed to list nodes", err.Error())
 	}
-	assert.True(t, len(nodes.Items) > 0)
+	assert.NotEmpty(t, nodes.Items)
 
 	template := framework.DefaultGameServer(framework.Namespace)
 	// choose port out of the minport/maxport range
@@ -667,7 +668,7 @@ func TestGameServerSelfAllocate(t *testing.T) {
 	}
 	defer framework.AgonesClient.AgonesV1().GameServers(framework.Namespace).Delete(ctx, readyGs.ObjectMeta.Name, metav1.DeleteOptions{}) // nolint: errcheck
 
-	assert.Equal(t, readyGs.Status.State, agonesv1.GameServerStateReady)
+	assert.Equal(t, agonesv1.GameServerStateReady, readyGs.Status.State)
 	reply, err := framework.SendGameServerUDP(t, readyGs, "ALLOCATE")
 	if err != nil {
 		t.Fatalf("Could not message GameServer: %v", err)
@@ -694,7 +695,7 @@ func TestGameServerReadyAllocateReady(t *testing.T) {
 
 	defer framework.AgonesClient.AgonesV1().GameServers(framework.Namespace).Delete(ctx, readyGs.ObjectMeta.Name, metav1.DeleteOptions{}) // nolint: errcheck
 
-	require.Equal(t, readyGs.Status.State, agonesv1.GameServerStateReady)
+	require.Equal(t, agonesv1.GameServerStateReady, readyGs.Status.State)
 
 	logger.Info("Moving to Allocated")
 	reply, err := framework.SendGameServerUDP(t, readyGs, "ALLOCATE")
@@ -763,7 +764,7 @@ func TestGameServerWithPortsMappedToMultipleContainers(t *testing.T) {
 		t.Fatalf("Could not get a GameServer ready: %v", err)
 	}
 	defer framework.AgonesClient.AgonesV1().GameServers(framework.Namespace).Delete(ctx, readyGs.ObjectMeta.Name, metav1.DeleteOptions{}) // nolint: errcheck
-	assert.Equal(t, readyGs.Status.State, agonesv1.GameServerStateReady)
+	assert.Equal(t, agonesv1.GameServerStateReady, readyGs.Status.State)
 
 	interval := 2 * time.Second
 	timeOut := 60 * time.Second
@@ -846,7 +847,7 @@ func TestGameServerWithPortsMappedToInitSidecarContainers(t *testing.T) {
 		t.Fatalf("Could not get a GameServer ready: %v", err)
 	}
 	defer framework.AgonesClient.AgonesV1().GameServers(framework.Namespace).Delete(ctx, readyGs.ObjectMeta.Name, metav1.DeleteOptions{}) // nolint: errcheck
-	assert.Equal(t, readyGs.Status.State, agonesv1.GameServerStateReady)
+	assert.Equal(t, agonesv1.GameServerStateReady, readyGs.Status.State)
 
 	interval := 2 * time.Second
 	timeOut := 60 * time.Second
@@ -885,7 +886,7 @@ func TestGameServerReserve(t *testing.T) {
 		assert.FailNow(t, "Could not get a GameServer ready", err.Error())
 	}
 	defer framework.AgonesClient.AgonesV1().GameServers(framework.Namespace).Delete(ctx, gs.ObjectMeta.Name, metav1.DeleteOptions{}) // nolint: errcheck
-	assert.Equal(t, gs.Status.State, agonesv1.GameServerStateReady)
+	assert.Equal(t, agonesv1.GameServerStateReady, gs.Status.State)
 
 	reply, err := framework.SendGameServerUDP(t, gs, "RESERVE 0")
 	if err != nil {
@@ -930,7 +931,7 @@ func TestGameServerShutdown(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Could not get a GameServer ready: %v", err)
 	}
-	assert.Equal(t, readyGs.Status.State, agonesv1.GameServerStateReady)
+	assert.Equal(t, agonesv1.GameServerStateReady, readyGs.Status.State)
 
 	reply, err := framework.SendGameServerUDP(t, readyGs, "EXIT")
 	if err != nil {
@@ -979,11 +980,11 @@ func TestGameServerEvicted(t *testing.T) {
 		time.Sleep(3 * time.Second) // just make sure it comes in later
 		log.WithField("name", eviction.ObjectMeta.Name).Info("Evicting pod!")
 		err := pods.EvictV1(context.Background(), eviction)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}()
 
 	_, err = framework.WaitForGameServerState(t, newGs, agonesv1.GameServerStateUnhealthy, 10*time.Minute)
-	require.NoError(t, err, fmt.Sprintf("waiting for [%v] GameServer Unhealthy state timed out (%v)", gs.Status.State, gs.Name))
+	require.NoError(t, err, "waiting for [%v] GameServer Unhealthy state timed out (%v)", gs.Status.State, gs.Name)
 }
 
 func TestGameServerPassthroughPort(t *testing.T) {
@@ -994,7 +995,7 @@ func TestGameServerPassthroughPort(t *testing.T) {
 	gs.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{{Name: "PASSTHROUGH", Value: "TRUE"}}
 	// gate
 	errs := gs.Validate(agtesting.FakeAPIHooks{})
-	assert.Len(t, errs, 0)
+	assert.Empty(t, errs)
 
 	readyGs, err := framework.CreateGameServerAndWaitUntilReady(t, framework.Namespace, gs)
 	if err != nil {
@@ -1021,7 +1022,7 @@ func TestGameServerPortPolicyNone(t *testing.T) {
 	gs.Spec.Ports[0] = agonesv1.GameServerPort{PortPolicy: agonesv1.None, ContainerPort: 7777}
 	// gate
 	errs := gs.Validate(agtesting.FakeAPIHooks{})
-	assert.Len(t, errs, 0)
+	assert.Empty(t, errs)
 
 	readyGs, err := framework.CreateGameServerAndWaitUntilReady(t, framework.Namespace, gs)
 	if err != nil {
@@ -1046,7 +1047,7 @@ func TestGameServerTcpProtocol(t *testing.T) {
 	gs.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{{Name: "TCP", Value: "TRUE"}}
 
 	errs := gs.Validate(agtesting.FakeAPIHooks{})
-	require.Len(t, errs, 0)
+	require.Empty(t, errs)
 
 	readyGs, err := framework.CreateGameServerAndWaitUntilReady(t, framework.Namespace, gs)
 	require.NoError(t, err)
@@ -1075,7 +1076,7 @@ func TestGameServerTcpUdpProtocol(t *testing.T) {
 	gs.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{{Name: "TCP", Value: "TRUE"}}
 
 	errs := gs.Validate(agtesting.FakeAPIHooks{})
-	require.Len(t, errs, 0)
+	require.Empty(t, errs)
 
 	readyGs, err := framework.CreateGameServerAndWaitUntilReady(t, framework.Namespace, gs)
 	if err != nil {
@@ -1126,7 +1127,7 @@ func TestGameServerStaticTcpUdpProtocol(t *testing.T) {
 	gs.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{{Name: "TCP", Value: "TRUE"}}
 
 	errs := gs.Validate(agtesting.FakeAPIHooks{})
-	require.Len(t, errs, 0)
+	require.Empty(t, errs)
 
 	readyGs, err := framework.CreateGameServerAndWaitUntilReady(t, framework.Namespace, gs)
 	require.NoError(t, err)
@@ -1175,7 +1176,7 @@ func TestGameServerStaticTcpProtocol(t *testing.T) {
 	gs.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{{Name: "TCP", Value: "TRUE"}}
 
 	errs := gs.Validate(agtesting.FakeAPIHooks{})
-	require.Len(t, errs, 0)
+	require.Empty(t, errs)
 
 	readyGs, err := framework.CreateGameServerAndWaitUntilReady(t, framework.Namespace, gs)
 	require.NoError(t, err)
@@ -1199,7 +1200,7 @@ func TestGameServerStaticUdpProtocol(t *testing.T) {
 	gs.Spec.Ports[0].HostPort = 7000
 
 	errs := gs.Validate(agtesting.FakeAPIHooks{})
-	require.Len(t, errs, 0)
+	require.Empty(t, errs)
 
 	readyGs, err := framework.CreateGameServerAndWaitUntilReady(t, framework.Namespace, gs)
 	require.NoError(t, err)
@@ -1219,7 +1220,7 @@ func TestGameServerWithoutPort(t *testing.T) {
 	gs.Spec.Ports = nil
 
 	errs := gs.Validate(agtesting.FakeAPIHooks{})
-	assert.Len(t, errs, 0)
+	assert.Empty(t, errs)
 
 	readyGs, err := framework.CreateGameServerAndWaitUntilReady(t, framework.Namespace, gs)
 
@@ -1238,13 +1239,14 @@ func TestGameServerResourceValidation(t *testing.T) {
 	gs.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory] = resource.MustParse("128Mi")
 
 	errs := gs.Validate(agtesting.FakeAPIHooks{})
-	assert.False(t, len(errs) == 0)
+	assert.NotEmpty(t, errs)
 
 	gsClient := framework.AgonesClient.AgonesV1().GameServers(framework.Namespace)
 
 	_, err := gsClient.Create(ctx, gs.DeepCopy(), metav1.CreateOptions{})
-	assert.NotNil(t, err)
-	statusErr, ok := err.(*k8serrors.StatusError)
+	assert.Error(t, err)
+	var statusErr *k8serrors.StatusError
+	ok := errors.As(err, &statusErr)
 	assert.True(t, ok)
 	assert.Len(t, statusErr.Status().Details.Causes, 1)
 	assert.Equal(t, metav1.CauseTypeFieldValueInvalid, statusErr.Status().Details.Causes[0].Type)
@@ -1252,8 +1254,8 @@ func TestGameServerResourceValidation(t *testing.T) {
 
 	gs.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("-50m")
 	_, err = gsClient.Create(ctx, gs.DeepCopy(), metav1.CreateOptions{})
-	assert.NotNil(t, err)
-	statusErr, ok = err.(*k8serrors.StatusError)
+	assert.Error(t, err)
+	ok = errors.As(err, &statusErr)
 	assert.True(t, ok)
 	assert.Len(t, statusErr.Status().Details.Causes, 2)
 	sort.Slice(statusErr.Status().Details.Causes, func(i, j int) bool {
@@ -1271,7 +1273,7 @@ func TestGameServerResourceValidation(t *testing.T) {
 
 	// confirm we have a valid GameServer before running the test
 	errs = gs.Validate(agtesting.FakeAPIHooks{})
-	require.Len(t, errs, 0)
+	require.Empty(t, errs)
 
 	gsCopy, err := gsClient.Create(ctx, gs.DeepCopy(), metav1.CreateOptions{})
 	require.NoError(t, err)
@@ -1335,7 +1337,7 @@ func TestGameServerSetPlayerCapacity(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Could not get a GameServer ready: %v", err)
 		}
-		assert.Equal(t, gs.Status.State, agonesv1.GameServerStateReady)
+		assert.Equal(t, agonesv1.GameServerStateReady, gs.Status.State)
 		assert.Equal(t, int64(0), gs.Status.Players.Capacity)
 
 		reply, err := framework.SendGameServerUDP(t, gs, "PLAYER_CAPACITY")
@@ -1373,7 +1375,7 @@ func TestGameServerSetPlayerCapacity(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Could not get a GameServer ready: %v", err)
 		}
-		assert.Equal(t, gs.Status.State, agonesv1.GameServerStateReady)
+		assert.Equal(t, agonesv1.GameServerStateReady, gs.Status.State)
 		assert.Equal(t, int64(10), gs.Status.Players.Capacity)
 
 		reply, err := framework.SendGameServerUDP(t, gs, "PLAYER_CAPACITY")
@@ -1418,7 +1420,7 @@ func TestPlayerConnectWithCapacityZero(t *testing.T) {
 	gs.Spec.Players = &agonesv1.PlayersSpec{InitialCapacity: playerCount}
 	gs, err := framework.CreateGameServerAndWaitUntilReady(t, framework.Namespace, gs)
 	require.NoError(t, err)
-	assert.Equal(t, gs.Status.State, agonesv1.GameServerStateReady)
+	assert.Equal(t, agonesv1.GameServerStateReady, gs.Status.State)
 	assert.Equal(t, playerCount, gs.Status.Players.Capacity)
 
 	// add a player
@@ -1446,7 +1448,7 @@ func TestPlayerConnectAndDisconnect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Could not get a GameServer ready: %v", err)
 	}
-	assert.Equal(t, gs.Status.State, agonesv1.GameServerStateReady)
+	assert.Equal(t, agonesv1.GameServerStateReady, gs.Status.State)
 	assert.Equal(t, playerCount, gs.Status.Players.Capacity)
 
 	// add three players in quick succession
@@ -1803,7 +1805,7 @@ func TestSideCarCommunicatesWhileTerminating(t *testing.T) {
 	gs.Spec.Template.Spec.TerminationGracePeriodSeconds = &minute
 	readyGs, err := framework.CreateGameServerAndWaitUntilReady(t, framework.Namespace, gs)
 	require.NoError(t, err)
-	require.Equal(t, readyGs.Status.State, agonesv1.GameServerStateReady)
+	require.Equal(t, agonesv1.GameServerStateReady, readyGs.Status.State)
 
 	// delete the GameServer
 	gameServers := framework.AgonesClient.AgonesV1().GameServers(framework.Namespace)
@@ -1843,7 +1845,7 @@ func TestGracefulShutdown(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Could not get a GameServer ready: %v", err)
 	}
-	assert.Equal(t, readyGs.Status.State, agonesv1.GameServerStateReady)
+	assert.Equal(t, agonesv1.GameServerStateReady, readyGs.Status.State)
 	gameservers := framework.AgonesClient.AgonesV1().GameServers(framework.Namespace)
 	err = gameservers.Delete(ctx, readyGs.ObjectMeta.Name, metav1.DeleteOptions{})
 	require.NoError(t, err)
@@ -1942,7 +1944,7 @@ func TestGameServerPatch(t *testing.T) {
 	// Confirm patch is applied correctly
 	patchedGs, err := framework.AgonesClient.AgonesV1().GameServers(framework.Namespace).Patch(ctx, gs.GetObjectMeta().GetName(), types.JSONPatchType, patch, metav1.PatchOptions{})
 	require.NoError(t, err)
-	require.Equal(t, patchedGs.ObjectMeta.Labels, map[string]string{"foo": "foo-value"})
+	require.Equal(t, map[string]string{"foo": "foo-value"}, patchedGs.ObjectMeta.Labels)
 	require.NotEqual(t, patchedGs.ObjectMeta.ResourceVersion, gs.ObjectMeta.ResourceVersion)
 
 	// Confirm a patch applied to an old version of a game server is not applied
@@ -1955,7 +1957,7 @@ func TestGameServerPatch(t *testing.T) {
 
 	getGs, err := framework.AgonesClient.AgonesV1().GameServers(framework.Namespace).Get(ctx, gs.ObjectMeta.Name, metav1.GetOptions{})
 	require.NoError(t, err)
-	require.Equal(t, getGs.ObjectMeta.Labels, map[string]string{"foo": "foo-value"})
+	require.Equal(t, map[string]string{"foo": "foo-value"}, getGs.ObjectMeta.Labels)
 	require.Equal(t, getGs.ObjectMeta.ResourceVersion, patchedGs.ObjectMeta.ResourceVersion)
 
 	// Confirm patch goes through with the most up-to-date game server
@@ -1966,10 +1968,10 @@ func TestGameServerPatch(t *testing.T) {
 
 	rePatchedGs, err := framework.AgonesClient.AgonesV1().GameServers(framework.Namespace).Patch(ctx, gs.GetObjectMeta().GetName(), types.JSONPatchType, patch, metav1.PatchOptions{})
 	require.NoError(t, err)
-	require.Equal(t, rePatchedGs.ObjectMeta.Labels, map[string]string{"bar": "bar-value"})
+	require.Equal(t, map[string]string{"bar": "bar-value"}, rePatchedGs.ObjectMeta.Labels)
 
 	getGs, err = framework.AgonesClient.AgonesV1().GameServers(framework.Namespace).Get(ctx, gs.ObjectMeta.Name, metav1.GetOptions{})
 	require.NoError(t, err)
-	require.Equal(t, getGs.ObjectMeta.Labels, map[string]string{"bar": "bar-value"})
+	require.Equal(t, map[string]string{"bar": "bar-value"}, getGs.ObjectMeta.Labels)
 	require.Equal(t, getGs.ObjectMeta.ResourceVersion, rePatchedGs.ObjectMeta.ResourceVersion)
 }

--- a/test/e2e/gameserverallocation_test.go
+++ b/test/e2e/gameserverallocation_test.go
@@ -948,7 +948,7 @@ func TestMultiClusterAllocationOnLocalCluster(t *testing.T) {
 
 			namespace := fmt.Sprintf("gsa-multicluster-local-%s", uuid.NewUUID())
 			err := framework.CreateNamespace(namespace)
-			if !assert.Nil(t, err) {
+			if !assert.NoError(t, err) {
 				return
 			}
 			defer func() {
@@ -961,7 +961,7 @@ func TestMultiClusterAllocationOnLocalCluster(t *testing.T) {
 			fleet := defaultFleet(namespace)
 			fleet.Spec.Scheduling = strategy
 			flt, err := fleets.Create(ctx, fleet, metav1.CreateOptions{})
-			if assert.Nil(t, err) {
+			if assert.NoError(t, err) {
 				defer fleets.Delete(ctx, flt.ObjectMeta.Name, metav1.DeleteOptions{}) // nolint:errcheck
 			}
 
@@ -985,7 +985,7 @@ func TestMultiClusterAllocationOnLocalCluster(t *testing.T) {
 				},
 			}
 			resp, err := framework.AgonesClient.MulticlusterV1().GameServerAllocationPolicies(fleet.ObjectMeta.Namespace).Create(ctx, mca, metav1.CreateOptions{})
-			if !assert.Nil(t, err) {
+			if !assert.NoError(t, err) {
 				assert.FailNowf(t, "GameServerAllocationPolicies(%v).Create(ctx, %v, metav1.CreateOptions{})", fleet.ObjectMeta.Namespace, mca)
 			}
 			assert.Equal(t, mca.Spec, resp.Spec)
@@ -1009,7 +1009,7 @@ func TestMultiClusterAllocationOnLocalCluster(t *testing.T) {
 				},
 			}
 			resp, err = framework.AgonesClient.MulticlusterV1().GameServerAllocationPolicies(fleet.ObjectMeta.Namespace).Create(ctx, mca, metav1.CreateOptions{})
-			if assert.Nil(t, err) {
+			if assert.NoError(t, err) {
 				assert.Equal(t, mca.Spec, resp.Spec)
 			}
 
@@ -1030,7 +1030,7 @@ func TestMultiClusterAllocationOnLocalCluster(t *testing.T) {
 				},
 			}
 			resp, err = framework.AgonesClient.MulticlusterV1().GameServerAllocationPolicies(fleet.ObjectMeta.Namespace).Create(ctx, mca, metav1.CreateOptions{})
-			if assert.Nil(t, err) {
+			if assert.NoError(t, err) {
 				assert.Equal(t, mca.Spec, resp.Spec)
 			}
 
@@ -1088,7 +1088,7 @@ func TestCreateFullFleetAndCantGameServerAllocate(t *testing.T) {
 			fleet := defaultFleet(framework.Namespace)
 			fleet.Spec.Scheduling = strategy
 			flt, err := fleets.Create(ctx, fleet, metav1.CreateOptions{})
-			if assert.Nil(t, err) {
+			if assert.NoError(t, err) {
 				defer fleets.Delete(ctx, flt.ObjectMeta.Name, metav1.DeleteOptions{}) // nolint:errcheck
 			}
 
@@ -1103,7 +1103,7 @@ func TestCreateFullFleetAndCantGameServerAllocate(t *testing.T) {
 			for i := 0; i < replicasCount; i++ {
 				var gsa2 *allocationv1.GameServerAllocation
 				gsa2, err = framework.AgonesClient.AllocationV1().GameServerAllocations(framework.Namespace).Create(ctx, gsa.DeepCopy(), metav1.CreateOptions{})
-				if assert.Nil(t, err) {
+				if assert.NoError(t, err) {
 					assert.Equal(t, allocationv1.GameServerAllocationAllocated, gsa2.Status.State)
 				}
 			}
@@ -1113,7 +1113,7 @@ func TestCreateFullFleetAndCantGameServerAllocate(t *testing.T) {
 			})
 
 			gsa, err = framework.AgonesClient.AllocationV1().GameServerAllocations(framework.Namespace).Create(ctx, gsa.DeepCopy(), metav1.CreateOptions{})
-			if assert.Nil(t, err) {
+			if assert.NoError(t, err) {
 				assert.Equal(t, string(allocationv1.GameServerAllocationUnAllocated), string(gsa.Status.State))
 			}
 		})
@@ -1194,7 +1194,7 @@ func TestGameServerAllocationPreferredSelection(t *testing.T) {
 	preferred.Spec.Replicas = 1
 	preferred.Spec.Template.ObjectMeta.Labels = label
 	preferred, err := fleets.Create(ctx, preferred, metav1.CreateOptions{})
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		defer fleets.Delete(ctx, preferred.ObjectMeta.Name, metav1.DeleteOptions{}) // nolint:errcheck
 	} else {
 		assert.FailNow(t, "could not create first fleet")
@@ -1205,7 +1205,7 @@ func TestGameServerAllocationPreferredSelection(t *testing.T) {
 	required.Spec.Replicas = 2
 	required.Spec.Template.ObjectMeta.Labels = label
 	required, err = fleets.Create(ctx, required, metav1.CreateOptions{})
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		defer fleets.Delete(ctx, required.ObjectMeta.Name, metav1.DeleteOptions{}) // nolint:errcheck
 	} else {
 		assert.FailNow(t, "could not create second fleet")
@@ -1223,20 +1223,20 @@ func TestGameServerAllocationPreferredSelection(t *testing.T) {
 		}}
 
 	gsa1, err := framework.AgonesClient.AllocationV1().GameServerAllocations(framework.Namespace).Create(ctx, gsa.DeepCopy(), metav1.CreateOptions{})
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		assert.Equal(t, allocationv1.GameServerAllocationAllocated, gsa1.Status.State)
 		gs, err := gameServers.Get(ctx, gsa1.Status.GameServerName, metav1.GetOptions{})
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, preferred.ObjectMeta.Name, gs.ObjectMeta.Labels[agonesv1.FleetNameLabel])
 	} else {
 		assert.FailNow(t, "could not completed gsa1 allocation")
 	}
 
 	gs2, err := framework.AgonesClient.AllocationV1().GameServerAllocations(framework.Namespace).Create(ctx, gsa.DeepCopy(), metav1.CreateOptions{})
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		assert.Equal(t, allocationv1.GameServerAllocationAllocated, gs2.Status.State)
 		gs, err := gameServers.Get(ctx, gs2.Status.GameServerName, metav1.GetOptions{})
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, required.ObjectMeta.Name, gs.ObjectMeta.Labels[agonesv1.FleetNameLabel])
 	} else {
 		assert.FailNow(t, "could not completed gs2 allocation")
@@ -1245,7 +1245,7 @@ func TestGameServerAllocationPreferredSelection(t *testing.T) {
 	// delete the preferred gameserver, and then let's try allocating again, make sure it goes back to the
 	// preferred one
 	err = gameServers.Delete(ctx, gsa1.Status.GameServerName, metav1.DeleteOptions{})
-	if !assert.Nil(t, err) {
+	if !assert.NoError(t, err) {
 		assert.FailNow(t, "could not delete gameserver")
 	}
 
@@ -1259,16 +1259,16 @@ func TestGameServerAllocationPreferredSelection(t *testing.T) {
 
 		return false, err
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// now wait for another one to come along
 	framework.AssertFleetCondition(t, preferred, e2e.FleetReadyCount(preferred.Spec.Replicas))
 
 	gsa3, err := framework.AgonesClient.AllocationV1().GameServerAllocations(framework.Namespace).Create(ctx, gsa.DeepCopy(), metav1.CreateOptions{})
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		assert.Equal(t, allocationv1.GameServerAllocationAllocated, gsa3.Status.State)
 		gs, err := gameServers.Get(ctx, gsa3.Status.GameServerName, metav1.GetOptions{})
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, preferred.ObjectMeta.Name, gs.ObjectMeta.Labels[agonesv1.FleetNameLabel])
 	}
 }
@@ -1339,7 +1339,7 @@ func TestGameServerAllocationDeletionOnUnAllocate(t *testing.T) {
 		}}
 
 	gsa, err := allocations.Create(ctx, gsa.DeepCopy(), metav1.CreateOptions{})
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		assert.Equal(t, allocationv1.GameServerAllocationUnAllocated, gsa.Status.State)
 	}
 }
@@ -1357,7 +1357,7 @@ func TestGameServerAllocationDuringMultipleAllocationClients(t *testing.T) {
 	preferred.Spec.Replicas = 150
 	preferred.Spec.Template.ObjectMeta.Labels = label
 	preferred, err := fleets.Create(ctx, preferred, metav1.CreateOptions{})
-	if assert.Nil(t, err) {
+	if assert.NoError(t, err) {
 		defer fleets.Delete(ctx, preferred.ObjectMeta.Name, metav1.DeleteOptions{}) // nolint:errcheck
 	} else {
 		assert.FailNow(t, "could not create first fleet")

--- a/test/e2e/ping_test.go
+++ b/test/e2e/ping_test.go
@@ -103,7 +103,7 @@ func externalIP(t *testing.T, kubeCore typedv1.NodesGetter, svc *corev1.Service)
 	// likely this is minikube, so go get the node ip
 	if svc.Spec.Type == corev1.ServiceTypeNodePort {
 		nodes, err := kubeCore.Nodes().List(ctx, metav1.ListOptions{})
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Len(t, nodes.Items, 1, "Should only be 1 node on minikube")
 
 		addresses := nodes.Items[0].Status.Addresses

--- a/test/sdk/websocket-watch/ws-watch-test.go
+++ b/test/sdk/websocket-watch/ws-watch-test.go
@@ -54,7 +54,7 @@ func main() {
 	}
 	response, respErr := httpClient.Do(req)
 	if respErr != nil {
-		log.Fatalf("Could not post reserve request: %v", reqErr) // nolint: gocritic
+		log.Fatalf("Could not post reserve request: %v", respErr) // nolint: gocritic
 	}
 	defer response.Body.Close() // nolint: errcheck
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/agones-dev/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/agones-dev/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/agones-dev/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

Turns on asasalint, bidichk, durationcheck, errname, errorlint, fatcontext, gocheckcompilerdirectives, gosec, makezero, nilerr, nilnesserr, noctx, reassign, testifylint, and wastedassign in golangci-lint, with targeted excludes/overrides for gosec (G104/G115) and testifylint (require-error), and per-path overrides for tests, build/, and the GenAI example.

Fixes the issues these linters surfaced across the tree.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
Use "Work on #<issue number>" if you wish to reference the issue without closing it.
-->
Technically part of the OpenSSF work I'm doing as part of #4421

**Did you use AI tools in preparing this PR?**:
<!--
If you used AI tools in preparing your PR, you must disclose this in the description of your PR.
--->
Y

**Special notes for your reviewer**:

Someone might like the new use of modern error checking and comparison 😄 .
