### PR TITLE
fix memory leak when delete game server

### DIFF
--- a/pkg/gameservers/pernodecounter.go
+++ b/pkg/gameservers/pernodecounter.go
@@ -150,6 +150,8 @@ func NewPerNodeCounter(
 			pnc.countMutex.Lock()
 			defer pnc.countMutex.Unlock()
 
+			uid := gs.ObjectMeta.UID
+
 			// Check if we've tracked this GameServer
 			processed, exists := pnc.processed[gs.ObjectMeta.UID]
 			if exists {
@@ -171,7 +173,11 @@ func NewPerNodeCounter(
 			}
 
 			// Remove from tracking since the object is deleted
-			delete(pnc.processed, gs.ObjectMeta.UID)
+			delete(pnc.processed, uid)
+
+			pnc.logger.
+				WithField("processedAfter", len(pnc.processed)).
+				Info("PNCLEAK: DeleteFunc")
 		},
 	})
 

--- a/pkg/gameservers/pernodecounter.go
+++ b/pkg/gameservers/pernodecounter.go
@@ -174,10 +174,6 @@ func NewPerNodeCounter(
 
 			// Remove from tracking since the object is deleted
 			delete(pnc.processed, uid)
-
-			pnc.logger.
-				WithField("processedAfter", len(pnc.processed)).
-				Info("PNCLEAK: DeleteFunc")
 		},
 	})
 

--- a/pkg/gameservers/pernodecounter.go
+++ b/pkg/gameservers/pernodecounter.go
@@ -153,7 +153,7 @@ func NewPerNodeCounter(
 			uid := gs.ObjectMeta.UID
 
 			// Check if we've tracked this GameServer
-			processed, exists := pnc.processed[gs.ObjectMeta.UID]
+			processed, exists := pnc.processed[uid]
 			if exists {
 				// Use the tracked state for accurate counting, as the current state may not be
 				// allocated or ready at this point (could very well be Shutdown).

--- a/pkg/gameservers/pernodecounter_test.go
+++ b/pkg/gameservers/pernodecounter_test.go
@@ -15,6 +15,7 @@
 package gameservers
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -25,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	k8stesting "k8s.io/client-go/testing"
 )
@@ -34,6 +36,58 @@ const (
 	name1     = "node1"
 	name2     = "node2"
 )
+
+func TestPerNodeCounterMapLeak(t *testing.T) {
+	t.Parallel()
+
+	pnc, m := newFakePerNodeCounter()
+
+	processedLen := func() int {
+		pnc.countMutex.RLock()
+		defer pnc.countMutex.RUnlock()
+		return len(pnc.processed)
+	}
+
+	fakeWatch := watch.NewFake()
+	m.AgonesClient.AddWatchReactor("gameservers", k8stesting.DefaultWatchReactor(fakeWatch, nil))
+
+	_, cancel := agtesting.StartInformers(m)
+	defer cancel()
+
+	assert.Empty(t, pnc.Counts())
+
+	gss := make([]*agonesv1.GameServer, 0)
+
+	gs := &agonesv1.GameServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "gs", Namespace: defaultNs, UID: "uid-gs", ResourceVersion: "1"},
+		Status: agonesv1.GameServerStatus{
+			State: agonesv1.GameServerStateReady, NodeName: name1,
+		},
+	}
+
+	for i := range 10 {
+		name := fmt.Sprintf("gs%d", i)
+		uid := fmt.Sprintf("uid-gs%d", i)
+		gs.ObjectMeta.Name = name
+		gs.ObjectMeta.UID = types.UID(uid)
+
+		cgs := gs.DeepCopy()
+		fakeWatch.Add(cgs)
+		gss = append(gss, cgs)
+	}
+
+	require.Eventuallyf(t, func() bool {
+		return processedLen() == 10
+	}, 5*time.Second, time.Second, "len should be 10, instead: %v", processedLen())
+
+	for _, gs := range gss {
+		fakeWatch.Delete(gs)
+	}
+
+	require.Eventuallyf(t, func() bool {
+		return processedLen() == 0
+	}, 5*time.Second, time.Second, "len should be 0, instead: %v", processedLen())
+}
 
 func TestPerNodeCounterGameServerEvents(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/agones-dev/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/agones-dev/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/agones-dev/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind bug

/kind bug

**What this PR does / Why we need it**:

when delete game server, `pnc.processed` map never deleted element, because newly created `gs`'s uid is empty string!

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
Use "Work on #<issue number>" if you wish to reference the issue without closing it.
-->
Closes #

**Did you use AI tools in preparing this PR?**:
<!--
If you used AI tools in preparing your PR, you must disclose this in the description of your PR.
--->
N

**Special notes for your reviewer**:


