### PR TITLE
fix: gate x-kubernetes-patch-* CRD fields behind a Helm conditional

### DIFF
--- a/build/scripts/k8s-export-openapi/main.go
+++ b/build/scripts/k8s-export-openapi/main.go
@@ -389,6 +389,58 @@ func escapeDoubleBackslashes(filePath string) error {
 	return os.WriteFile(filePath, []byte(modifiedData), 0o644)
 }
 
+// patchKeys are OpenAPI extensions that are not valid CustomResourceDefinition schema fields, so
+// including them results in "unknown field" warnings on install, and errors on Kubernetes
+// distributions that decode strictly. They are wrapped in a Helm conditional so they can be opted
+// into by tools that make use of them, such as Kustomize.
+var patchKeys = []string{
+	"x-kubernetes-patch-merge-key:",
+	"x-kubernetes-patch-strategy:",
+}
+
+// wrapPatchKeys wraps each run of consecutive, equally indented patchKeys lines in a Helm
+// conditional. The conditional is emitted at column zero with whitespace trimming, so it renders
+// cleanly at any indentation depth.
+func wrapPatchKeys(yamlContent string) string {
+	lines := strings.Split(yamlContent, "\n")
+	out := make([]string, 0, len(lines))
+
+	for i := 0; i < len(lines); i++ {
+		if !isPatchKeyLine(lines[i]) {
+			out = append(out, lines[i])
+			continue
+		}
+
+		// Extend the run over following lines that are patch keys at the same indentation.
+		indent := leadingSpaces(lines[i])
+		j := i + 1
+		for j < len(lines) && isPatchKeyLine(lines[j]) && leadingSpaces(lines[j]) == indent {
+			j++
+		}
+
+		out = append(out, "{{- if .includeKubernetesPatchKeys }}")
+		out = append(out, lines[i:j]...)
+		out = append(out, "{{- end }}")
+		i = j - 1
+	}
+
+	return strings.Join(out, "\n")
+}
+
+func isPatchKeyLine(line string) bool {
+	trimmed := strings.TrimLeft(line, " ")
+	for _, key := range patchKeys {
+		if strings.HasPrefix(trimmed, key) {
+			return true
+		}
+	}
+	return false
+}
+
+func leadingSpaces(line string) int {
+	return len(line) - len(strings.TrimLeft(line, " "))
+}
+
 func jsonToHelmYaml(tmpDir, filename string) {
 	jsonFilePath := filepath.Join(tmpDir, filename+".json")
 	log.Println("JSONFILEPATH: ", jsonFilePath)
@@ -403,7 +455,7 @@ func jsonToHelmYaml(tmpDir, filename string) {
 	if err := json2yaml.Convert(&yamlBuffer, jsonReader); err != nil {
 		log.Fatalf("Failed to convert JSON to YAML: %s", err)
 	}
-	yamlContent := yamlBuffer.String()
+	yamlContent := wrapPatchKeys(yamlBuffer.String())
 
 	// Read boilerplate
 	boilerplateContent, err := os.ReadFile("../../boilerplate.yaml.txt")

--- a/build/scripts/k8s-export-openapi/main.go
+++ b/build/scripts/k8s-export-openapi/main.go
@@ -421,6 +421,8 @@ func wrapPatchKeys(yamlContent string) string {
 		out = append(out, "{{- if .includeKubernetesPatchKeys }}")
 		out = append(out, lines[i:j]...)
 		out = append(out, "{{- end }}")
+		// We'll continue from j, since this is where we ended up after at the end of the j loop
+		// which looked for the closing line for the template condition.
 		i = j - 1
 	}
 

--- a/build/scripts/k8s-export-openapi/main_test.go
+++ b/build/scripts/k8s-export-openapi/main_test.go
@@ -92,3 +92,63 @@ func TestRemoveFieldsKeepsPatchKeys(t *testing.T) {
 		t.Errorf("x-kubernetes-unions should be removed")
 	}
 }
+
+func TestWrapPatchKeys(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		in   string
+		want string
+	}{
+		"adjacent keys share a conditional": {
+			in: "    type: array\n" +
+				"    x-kubernetes-patch-merge-key: uid\n" +
+				"    x-kubernetes-patch-strategy: merge\n" +
+				"  resourceVersion:\n",
+			want: "    type: array\n" +
+				"{{- if .includeKubernetesPatchKeys }}\n" +
+				"    x-kubernetes-patch-merge-key: uid\n" +
+				"    x-kubernetes-patch-strategy: merge\n" +
+				"{{- end }}\n" +
+				"  resourceVersion:\n",
+		},
+		"standalone key": {
+			in: "    type: array\n" +
+				"    x-kubernetes-patch-strategy: merge\n",
+			want: "    type: array\n" +
+				"{{- if .includeKubernetesPatchKeys }}\n" +
+				"    x-kubernetes-patch-strategy: merge\n" +
+				"{{- end }}\n",
+		},
+		"runs at differing indentation are not merged": {
+			in: "        x-kubernetes-patch-strategy: merge\n" +
+				"    x-kubernetes-patch-strategy: merge,retainKeys\n",
+			want: "{{- if .includeKubernetesPatchKeys }}\n" +
+				"        x-kubernetes-patch-strategy: merge\n" +
+				"{{- end }}\n" +
+				"{{- if .includeKubernetesPatchKeys }}\n" +
+				"    x-kubernetes-patch-strategy: merge,retainKeys\n" +
+				"{{- end }}\n",
+		},
+		"other extensions are left alone": {
+			in: "      type: object\n" +
+				"      x-kubernetes-map-type: atomic\n" +
+				"      x-kubernetes-int-or-string: true\n",
+			want: "      type: object\n" +
+				"      x-kubernetes-map-type: atomic\n" +
+				"      x-kubernetes-int-or-string: true\n",
+		},
+		"no patch keys": {
+			in:   "description: a description\ntype: object\n",
+			want: "description: a description\ntype: object\n",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := wrapPatchKeys(tc.in); got != tc.want {
+				t.Errorf("wrapPatchKeys() =\n%s\nwant\n%s", got, tc.want)
+			}
+		})
+	}
+}

--- a/install/helm/agones/templates/crds/fleet.yaml
+++ b/install/helm/agones/templates/crds/fleet.yaml
@@ -138,6 +138,7 @@ spec:
                     "metadata" true 
                     "podPreserveUnknownFields" .Values.gameservers.podPreserveUnknownFields
                     "lists" .Values.gameservers.lists
+                    "includeKubernetesPatchKeys" .Values.agones.crds.includeKubernetesPatchKeys
                   }}
                   {{- include "gameserver.schema" $data | indent 17 }}
             status:

--- a/install/helm/agones/templates/crds/gameserver.yaml
+++ b/install/helm/agones/templates/crds/gameserver.yaml
@@ -64,6 +64,7 @@ spec:
           {{- $data := dict 
             "podPreserveUnknownFields" .Values.gameservers.podPreserveUnknownFields 
             "lists" .Values.gameservers.lists
+            "includeKubernetesPatchKeys" .Values.agones.crds.includeKubernetesPatchKeys
           }}
           {{- include "gameserver.schema" $data | indent 9 }}{{- /* include the schema then status, as it's easier to align */ -}}
           {{- include "gameserver.status" $data | indent 11 }}

--- a/install/helm/agones/templates/crds/gameserverset.yaml
+++ b/install/helm/agones/templates/crds/gameserverset.yaml
@@ -117,6 +117,7 @@ spec:
                     "metadata" true 
                     "podPreserveUnknownFields" .Values.gameservers.podPreserveUnknownFields
                     "lists" .Values.gameservers.lists
+                    "includeKubernetesPatchKeys" .Values.agones.crds.includeKubernetesPatchKeys
                   }}
                   {{- include "gameserver.schema" $data | indent 18 }}
             status:

--- a/install/helm/agones/templates/crds/k8s/_io.k8s.api.core.v1.PodTemplateSpec.yaml
+++ b/install/helm/agones/templates/crds/k8s/_io.k8s.api.core.v1.PodTemplateSpec.yaml
@@ -50,7 +50,9 @@ properties:
         items:
           type: string
         type: array
+{{- if .includeKubernetesPatchKeys }}
         x-kubernetes-patch-strategy: merge
+{{- end }}
       generateName:
         description: |-
           GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
@@ -135,8 +137,10 @@ properties:
           type: object
           x-kubernetes-map-type: atomic
         type: array
+{{- if .includeKubernetesPatchKeys }}
         x-kubernetes-patch-merge-key: uid
         x-kubernetes-patch-strategy: merge
+{{- end }}
       resourceVersion:
         description: |-
           An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
@@ -838,8 +842,10 @@ properties:
                   - name
                 type: object
               type: array
+{{- if .includeKubernetesPatchKeys }}
               x-kubernetes-patch-merge-key: name
               x-kubernetes-patch-strategy: merge
+{{- end }}
             envFrom:
               description: List of sources to populate environment variables in the container. The keys defined within a source may consist of any printable ASCII characters except '='. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
               items:
@@ -1328,8 +1334,10 @@ properties:
                   - containerPort
                 type: object
               type: array
+{{- if .includeKubernetesPatchKeys }}
               x-kubernetes-patch-merge-key: containerPort
               x-kubernetes-patch-strategy: merge
+{{- end }}
             readinessProbe:
               description: "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
               properties:
@@ -1795,8 +1803,10 @@ properties:
                   - devicePath
                 type: object
               type: array
+{{- if .includeKubernetesPatchKeys }}
               x-kubernetes-patch-merge-key: devicePath
               x-kubernetes-patch-strategy: merge
+{{- end }}
             volumeMounts:
               description: Pod volumes to mount into the container's filesystem. Cannot be updated.
               items:
@@ -1846,8 +1856,10 @@ properties:
                   - mountPath
                 type: object
               type: array
+{{- if .includeKubernetesPatchKeys }}
               x-kubernetes-patch-merge-key: mountPath
               x-kubernetes-patch-strategy: merge
+{{- end }}
             workingDir:
               description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
               type: string
@@ -1855,8 +1867,10 @@ properties:
             - name
           type: object
         type: array
+{{- if .includeKubernetesPatchKeys }}
         x-kubernetes-patch-merge-key: name
         x-kubernetes-patch-strategy: merge
+{{- end }}
       dnsConfig:
         description: Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.
         properties:
@@ -2018,8 +2032,10 @@ properties:
                   - name
                 type: object
               type: array
+{{- if .includeKubernetesPatchKeys }}
               x-kubernetes-patch-merge-key: name
               x-kubernetes-patch-strategy: merge
+{{- end }}
             envFrom:
               description: List of sources to populate environment variables in the container. The keys defined within a source may consist of any printable ASCII characters except '='. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
               items:
@@ -2508,8 +2524,10 @@ properties:
                   - containerPort
                 type: object
               type: array
+{{- if .includeKubernetesPatchKeys }}
               x-kubernetes-patch-merge-key: containerPort
               x-kubernetes-patch-strategy: merge
+{{- end }}
             readinessProbe:
               description: Probes are not allowed for ephemeral containers.
               properties:
@@ -2981,8 +2999,10 @@ properties:
                   - devicePath
                 type: object
               type: array
+{{- if .includeKubernetesPatchKeys }}
               x-kubernetes-patch-merge-key: devicePath
               x-kubernetes-patch-strategy: merge
+{{- end }}
             volumeMounts:
               description: Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers. Cannot be updated.
               items:
@@ -3032,8 +3052,10 @@ properties:
                   - mountPath
                 type: object
               type: array
+{{- if .includeKubernetesPatchKeys }}
               x-kubernetes-patch-merge-key: mountPath
               x-kubernetes-patch-strategy: merge
+{{- end }}
             workingDir:
               description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
               type: string
@@ -3041,8 +3063,10 @@ properties:
             - name
           type: object
         type: array
+{{- if .includeKubernetesPatchKeys }}
         x-kubernetes-patch-merge-key: name
         x-kubernetes-patch-strategy: merge
+{{- end }}
       hostAliases:
         description: HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
         items:
@@ -3059,8 +3083,10 @@ properties:
             - ip
           type: object
         type: array
+{{- if .includeKubernetesPatchKeys }}
         x-kubernetes-patch-merge-key: ip
         x-kubernetes-patch-strategy: merge
+{{- end }}
       hostIPC:
         description: "Use the host's ipc namespace. Optional: Default to false."
         type: boolean
@@ -3092,8 +3118,10 @@ properties:
           type: object
           x-kubernetes-map-type: atomic
         type: array
+{{- if .includeKubernetesPatchKeys }}
         x-kubernetes-patch-merge-key: name
         x-kubernetes-patch-strategy: merge
+{{- end }}
       initContainers:
         description: "List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/"
         items:
@@ -3211,8 +3239,10 @@ properties:
                   - name
                 type: object
               type: array
+{{- if .includeKubernetesPatchKeys }}
               x-kubernetes-patch-merge-key: name
               x-kubernetes-patch-strategy: merge
+{{- end }}
             envFrom:
               description: List of sources to populate environment variables in the container. The keys defined within a source may consist of any printable ASCII characters except '='. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
               items:
@@ -3701,8 +3731,10 @@ properties:
                   - containerPort
                 type: object
               type: array
+{{- if .includeKubernetesPatchKeys }}
               x-kubernetes-patch-merge-key: containerPort
               x-kubernetes-patch-strategy: merge
+{{- end }}
             readinessProbe:
               description: "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
               properties:
@@ -4168,8 +4200,10 @@ properties:
                   - devicePath
                 type: object
               type: array
+{{- if .includeKubernetesPatchKeys }}
               x-kubernetes-patch-merge-key: devicePath
               x-kubernetes-patch-strategy: merge
+{{- end }}
             volumeMounts:
               description: Pod volumes to mount into the container's filesystem. Cannot be updated.
               items:
@@ -4219,8 +4253,10 @@ properties:
                   - mountPath
                 type: object
               type: array
+{{- if .includeKubernetesPatchKeys }}
               x-kubernetes-patch-merge-key: mountPath
               x-kubernetes-patch-strategy: merge
+{{- end }}
             workingDir:
               description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
               type: string
@@ -4228,8 +4264,10 @@ properties:
             - name
           type: object
         type: array
+{{- if .includeKubernetesPatchKeys }}
         x-kubernetes-patch-merge-key: name
         x-kubernetes-patch-strategy: merge
+{{- end }}
       nodeName:
         description: NodeName indicates in which node this pod is scheduled. If empty, this pod is a candidate for scheduling by the scheduler defined in schedulerName. Once this field is set, the kubelet for this node becomes responsible for the lifecycle of this pod. This field should not be used to express a desire for the pod to be scheduled on a specific node. https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodename
         type: string
@@ -4319,8 +4357,10 @@ properties:
             - name
           type: object
         type: array
+{{- if .includeKubernetesPatchKeys }}
         x-kubernetes-patch-merge-key: name
         x-kubernetes-patch-strategy: merge,retainKeys
+{{- end }}
       resources:
         description: |-
           Resources is the total amount of CPU and Memory resources required by all containers in the pod. It supports specifying Requests and Limits for "cpu", "memory" and "hugepages-" resource names only. ResourceClaims are not supported.
@@ -4392,8 +4432,10 @@ properties:
             - name
           type: object
         type: array
+{{- if .includeKubernetesPatchKeys }}
         x-kubernetes-patch-merge-key: name
         x-kubernetes-patch-strategy: merge
+{{- end }}
       securityContext:
         description: "SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field."
         properties:
@@ -4721,8 +4763,10 @@ properties:
             - whenUnsatisfiable
           type: object
         type: array
+{{- if .includeKubernetesPatchKeys }}
         x-kubernetes-patch-merge-key: topologyKey
         x-kubernetes-patch-strategy: merge
+{{- end }}
       volumes:
         description: "List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes"
         items:
@@ -5043,7 +5087,9 @@ properties:
                           items:
                             type: string
                           type: array
+{{- if .includeKubernetesPatchKeys }}
                           x-kubernetes-patch-strategy: merge
+{{- end }}
                         generateName:
                           description: |-
                             GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
@@ -5128,8 +5174,10 @@ properties:
                             type: object
                             x-kubernetes-map-type: atomic
                           type: array
+{{- if .includeKubernetesPatchKeys }}
                           x-kubernetes-patch-merge-key: uid
                           x-kubernetes-patch-strategy: merge
+{{- end }}
                         resourceVersion:
                           description: |-
                             An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
@@ -5998,8 +6046,10 @@ properties:
             - name
           type: object
         type: array
+{{- if .includeKubernetesPatchKeys }}
         x-kubernetes-patch-merge-key: name
         x-kubernetes-patch-strategy: merge,retainKeys
+{{- end }}
       workloadRef:
         description: WorkloadRef provides a reference to the Workload object that this Pod belongs to. This field is used by the scheduler to identify the PodGroup and apply the correct group scheduling policies. The Workload object referenced by this field may not exist at the time the Pod is created. This field is immutable, but a Workload object with the same name may be recreated with different policies. Doing this during pod scheduling may result in the placement not conforming to the expected policies.
         properties:

--- a/install/helm/agones/templates/crds/k8s/_io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.yaml
+++ b/install/helm/agones/templates/crds/k8s/_io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.yaml
@@ -47,7 +47,9 @@ properties:
     items:
       type: string
     type: array
+{{- if .includeKubernetesPatchKeys }}
     x-kubernetes-patch-strategy: merge
+{{- end }}
   generateName:
     description: |-
       GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
@@ -132,8 +134,10 @@ properties:
       type: object
       x-kubernetes-map-type: atomic
     type: array
+{{- if .includeKubernetesPatchKeys }}
     x-kubernetes-patch-merge-key: uid
     x-kubernetes-patch-strategy: merge
+{{- end }}
   resourceVersion:
     description: |-
       An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.

--- a/install/helm/agones/values.schema.json
+++ b/install/helm/agones/values.schema.json
@@ -44,6 +44,9 @@
             "cleanupJobTTL": {
               "type": "integer",
               "minimum": 0
+            },
+            "includeKubernetesPatchKeys": {
+              "type": "boolean"
             }
           },
           "if": {

--- a/install/helm/agones/values.yaml
+++ b/install/helm/agones/values.yaml
@@ -34,6 +34,7 @@ agones:
     install: true
     cleanupOnDelete: true
     cleanupJobTTL: 60
+    includeKubernetesPatchKeys: false
   serviceaccount:
     allocator:
       name: agones-allocator

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -348,7 +348,6 @@ spec:
                          items:
                            type: string
                          type: array
-                         x-kubernetes-patch-strategy: merge
                        generateName:
                          description: |-
                            GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
@@ -433,8 +432,6 @@ spec:
                            type: object
                            x-kubernetes-map-type: atomic
                          type: array
-                         x-kubernetes-patch-merge-key: uid
-                         x-kubernetes-patch-strategy: merge
                        resourceVersion:
                          description: |-
                            An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
@@ -493,7 +490,6 @@ spec:
                                  items:
                                    type: string
                                  type: array
-                                 x-kubernetes-patch-strategy: merge
                                generateName:
                                  description: |-
                                    GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
@@ -578,8 +574,6 @@ spec:
                                    type: object
                                    x-kubernetes-map-type: atomic
                                  type: array
-                                 x-kubernetes-patch-merge-key: uid
-                                 x-kubernetes-patch-strategy: merge
                                resourceVersion:
                                  description: |-
                                    An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
@@ -1281,8 +1275,6 @@ spec:
                                            - name
                                          type: object
                                        type: array
-                                       x-kubernetes-patch-merge-key: name
-                                       x-kubernetes-patch-strategy: merge
                                      envFrom:
                                        description: List of sources to populate environment variables in the container. The keys defined within a source may consist of any printable ASCII characters except '='. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                        items:
@@ -1771,8 +1763,6 @@ spec:
                                            - containerPort
                                          type: object
                                        type: array
-                                       x-kubernetes-patch-merge-key: containerPort
-                                       x-kubernetes-patch-strategy: merge
                                      readinessProbe:
                                        description: "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
                                        properties:
@@ -2238,8 +2228,6 @@ spec:
                                            - devicePath
                                          type: object
                                        type: array
-                                       x-kubernetes-patch-merge-key: devicePath
-                                       x-kubernetes-patch-strategy: merge
                                      volumeMounts:
                                        description: Pod volumes to mount into the container's filesystem. Cannot be updated.
                                        items:
@@ -2289,8 +2277,6 @@ spec:
                                            - mountPath
                                          type: object
                                        type: array
-                                       x-kubernetes-patch-merge-key: mountPath
-                                       x-kubernetes-patch-strategy: merge
                                      workingDir:
                                        description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                        type: string
@@ -2298,8 +2284,6 @@ spec:
                                      - name
                                    type: object
                                  type: array
-                                 x-kubernetes-patch-merge-key: name
-                                 x-kubernetes-patch-strategy: merge
                                dnsConfig:
                                  description: Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.
                                  properties:
@@ -2461,8 +2445,6 @@ spec:
                                            - name
                                          type: object
                                        type: array
-                                       x-kubernetes-patch-merge-key: name
-                                       x-kubernetes-patch-strategy: merge
                                      envFrom:
                                        description: List of sources to populate environment variables in the container. The keys defined within a source may consist of any printable ASCII characters except '='. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                        items:
@@ -2951,8 +2933,6 @@ spec:
                                            - containerPort
                                          type: object
                                        type: array
-                                       x-kubernetes-patch-merge-key: containerPort
-                                       x-kubernetes-patch-strategy: merge
                                      readinessProbe:
                                        description: Probes are not allowed for ephemeral containers.
                                        properties:
@@ -3424,8 +3404,6 @@ spec:
                                            - devicePath
                                          type: object
                                        type: array
-                                       x-kubernetes-patch-merge-key: devicePath
-                                       x-kubernetes-patch-strategy: merge
                                      volumeMounts:
                                        description: Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers. Cannot be updated.
                                        items:
@@ -3475,8 +3453,6 @@ spec:
                                            - mountPath
                                          type: object
                                        type: array
-                                       x-kubernetes-patch-merge-key: mountPath
-                                       x-kubernetes-patch-strategy: merge
                                      workingDir:
                                        description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                        type: string
@@ -3484,8 +3460,6 @@ spec:
                                      - name
                                    type: object
                                  type: array
-                                 x-kubernetes-patch-merge-key: name
-                                 x-kubernetes-patch-strategy: merge
                                hostAliases:
                                  description: HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                                  items:
@@ -3502,8 +3476,6 @@ spec:
                                      - ip
                                    type: object
                                  type: array
-                                 x-kubernetes-patch-merge-key: ip
-                                 x-kubernetes-patch-strategy: merge
                                hostIPC:
                                  description: "Use the host's ipc namespace. Optional: Default to false."
                                  type: boolean
@@ -3535,8 +3507,6 @@ spec:
                                    type: object
                                    x-kubernetes-map-type: atomic
                                  type: array
-                                 x-kubernetes-patch-merge-key: name
-                                 x-kubernetes-patch-strategy: merge
                                initContainers:
                                  description: "List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/"
                                  items:
@@ -3654,8 +3624,6 @@ spec:
                                            - name
                                          type: object
                                        type: array
-                                       x-kubernetes-patch-merge-key: name
-                                       x-kubernetes-patch-strategy: merge
                                      envFrom:
                                        description: List of sources to populate environment variables in the container. The keys defined within a source may consist of any printable ASCII characters except '='. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                        items:
@@ -4144,8 +4112,6 @@ spec:
                                            - containerPort
                                          type: object
                                        type: array
-                                       x-kubernetes-patch-merge-key: containerPort
-                                       x-kubernetes-patch-strategy: merge
                                      readinessProbe:
                                        description: "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
                                        properties:
@@ -4611,8 +4577,6 @@ spec:
                                            - devicePath
                                          type: object
                                        type: array
-                                       x-kubernetes-patch-merge-key: devicePath
-                                       x-kubernetes-patch-strategy: merge
                                      volumeMounts:
                                        description: Pod volumes to mount into the container's filesystem. Cannot be updated.
                                        items:
@@ -4662,8 +4626,6 @@ spec:
                                            - mountPath
                                          type: object
                                        type: array
-                                       x-kubernetes-patch-merge-key: mountPath
-                                       x-kubernetes-patch-strategy: merge
                                      workingDir:
                                        description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                        type: string
@@ -4671,8 +4633,6 @@ spec:
                                      - name
                                    type: object
                                  type: array
-                                 x-kubernetes-patch-merge-key: name
-                                 x-kubernetes-patch-strategy: merge
                                nodeName:
                                  description: NodeName indicates in which node this pod is scheduled. If empty, this pod is a candidate for scheduling by the scheduler defined in schedulerName. Once this field is set, the kubelet for this node becomes responsible for the lifecycle of this pod. This field should not be used to express a desire for the pod to be scheduled on a specific node. https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodename
                                  type: string
@@ -4762,8 +4722,6 @@ spec:
                                      - name
                                    type: object
                                  type: array
-                                 x-kubernetes-patch-merge-key: name
-                                 x-kubernetes-patch-strategy: merge,retainKeys
                                resources:
                                  description: |-
                                    Resources is the total amount of CPU and Memory resources required by all containers in the pod. It supports specifying Requests and Limits for "cpu", "memory" and "hugepages-" resource names only. ResourceClaims are not supported.
@@ -4835,8 +4793,6 @@ spec:
                                      - name
                                    type: object
                                  type: array
-                                 x-kubernetes-patch-merge-key: name
-                                 x-kubernetes-patch-strategy: merge
                                securityContext:
                                  description: "SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field."
                                  properties:
@@ -5164,8 +5120,6 @@ spec:
                                      - whenUnsatisfiable
                                    type: object
                                  type: array
-                                 x-kubernetes-patch-merge-key: topologyKey
-                                 x-kubernetes-patch-strategy: merge
                                volumes:
                                  description: "List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes"
                                  items:
@@ -5486,7 +5440,6 @@ spec:
                                                    items:
                                                      type: string
                                                    type: array
-                                                   x-kubernetes-patch-strategy: merge
                                                  generateName:
                                                    description: |-
                                                      GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
@@ -5571,8 +5524,6 @@ spec:
                                                      type: object
                                                      x-kubernetes-map-type: atomic
                                                    type: array
-                                                   x-kubernetes-patch-merge-key: uid
-                                                   x-kubernetes-patch-strategy: merge
                                                  resourceVersion:
                                                    description: |-
                                                      An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
@@ -6441,8 +6392,6 @@ spec:
                                      - name
                                    type: object
                                  type: array
-                                 x-kubernetes-patch-merge-key: name
-                                 x-kubernetes-patch-strategy: merge,retainKeys
                                workloadRef:
                                  description: WorkloadRef provides a reference to the Workload object that this Pod belongs to. This field is used by the scheduler to identify the PodGroup and apply the correct group scheduling policies. The Workload object referenced by this field may not exist at the time the Pod is created. This field is immutable, but a Workload object with the same name may be recreated with different policies. Doing this during pod scheduling may result in the placement not conforming to the expected policies.
                                  properties:
@@ -7551,7 +7500,6 @@ spec:
                          items:
                            type: string
                          type: array
-                         x-kubernetes-patch-strategy: merge
                        generateName:
                          description: |-
                            GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
@@ -7636,8 +7584,6 @@ spec:
                            type: object
                            x-kubernetes-map-type: atomic
                          type: array
-                         x-kubernetes-patch-merge-key: uid
-                         x-kubernetes-patch-strategy: merge
                        resourceVersion:
                          description: |-
                            An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
@@ -8339,8 +8285,6 @@ spec:
                                    - name
                                  type: object
                                type: array
-                               x-kubernetes-patch-merge-key: name
-                               x-kubernetes-patch-strategy: merge
                              envFrom:
                                description: List of sources to populate environment variables in the container. The keys defined within a source may consist of any printable ASCII characters except '='. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                items:
@@ -8829,8 +8773,6 @@ spec:
                                    - containerPort
                                  type: object
                                type: array
-                               x-kubernetes-patch-merge-key: containerPort
-                               x-kubernetes-patch-strategy: merge
                              readinessProbe:
                                description: "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
                                properties:
@@ -9296,8 +9238,6 @@ spec:
                                    - devicePath
                                  type: object
                                type: array
-                               x-kubernetes-patch-merge-key: devicePath
-                               x-kubernetes-patch-strategy: merge
                              volumeMounts:
                                description: Pod volumes to mount into the container's filesystem. Cannot be updated.
                                items:
@@ -9347,8 +9287,6 @@ spec:
                                    - mountPath
                                  type: object
                                type: array
-                               x-kubernetes-patch-merge-key: mountPath
-                               x-kubernetes-patch-strategy: merge
                              workingDir:
                                description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                type: string
@@ -9356,8 +9294,6 @@ spec:
                              - name
                            type: object
                          type: array
-                         x-kubernetes-patch-merge-key: name
-                         x-kubernetes-patch-strategy: merge
                        dnsConfig:
                          description: Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.
                          properties:
@@ -9519,8 +9455,6 @@ spec:
                                    - name
                                  type: object
                                type: array
-                               x-kubernetes-patch-merge-key: name
-                               x-kubernetes-patch-strategy: merge
                              envFrom:
                                description: List of sources to populate environment variables in the container. The keys defined within a source may consist of any printable ASCII characters except '='. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                items:
@@ -10009,8 +9943,6 @@ spec:
                                    - containerPort
                                  type: object
                                type: array
-                               x-kubernetes-patch-merge-key: containerPort
-                               x-kubernetes-patch-strategy: merge
                              readinessProbe:
                                description: Probes are not allowed for ephemeral containers.
                                properties:
@@ -10482,8 +10414,6 @@ spec:
                                    - devicePath
                                  type: object
                                type: array
-                               x-kubernetes-patch-merge-key: devicePath
-                               x-kubernetes-patch-strategy: merge
                              volumeMounts:
                                description: Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers. Cannot be updated.
                                items:
@@ -10533,8 +10463,6 @@ spec:
                                    - mountPath
                                  type: object
                                type: array
-                               x-kubernetes-patch-merge-key: mountPath
-                               x-kubernetes-patch-strategy: merge
                              workingDir:
                                description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                type: string
@@ -10542,8 +10470,6 @@ spec:
                              - name
                            type: object
                          type: array
-                         x-kubernetes-patch-merge-key: name
-                         x-kubernetes-patch-strategy: merge
                        hostAliases:
                          description: HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                          items:
@@ -10560,8 +10486,6 @@ spec:
                              - ip
                            type: object
                          type: array
-                         x-kubernetes-patch-merge-key: ip
-                         x-kubernetes-patch-strategy: merge
                        hostIPC:
                          description: "Use the host's ipc namespace. Optional: Default to false."
                          type: boolean
@@ -10593,8 +10517,6 @@ spec:
                            type: object
                            x-kubernetes-map-type: atomic
                          type: array
-                         x-kubernetes-patch-merge-key: name
-                         x-kubernetes-patch-strategy: merge
                        initContainers:
                          description: "List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/"
                          items:
@@ -10712,8 +10634,6 @@ spec:
                                    - name
                                  type: object
                                type: array
-                               x-kubernetes-patch-merge-key: name
-                               x-kubernetes-patch-strategy: merge
                              envFrom:
                                description: List of sources to populate environment variables in the container. The keys defined within a source may consist of any printable ASCII characters except '='. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                items:
@@ -11202,8 +11122,6 @@ spec:
                                    - containerPort
                                  type: object
                                type: array
-                               x-kubernetes-patch-merge-key: containerPort
-                               x-kubernetes-patch-strategy: merge
                              readinessProbe:
                                description: "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
                                properties:
@@ -11669,8 +11587,6 @@ spec:
                                    - devicePath
                                  type: object
                                type: array
-                               x-kubernetes-patch-merge-key: devicePath
-                               x-kubernetes-patch-strategy: merge
                              volumeMounts:
                                description: Pod volumes to mount into the container's filesystem. Cannot be updated.
                                items:
@@ -11720,8 +11636,6 @@ spec:
                                    - mountPath
                                  type: object
                                type: array
-                               x-kubernetes-patch-merge-key: mountPath
-                               x-kubernetes-patch-strategy: merge
                              workingDir:
                                description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                type: string
@@ -11729,8 +11643,6 @@ spec:
                              - name
                            type: object
                          type: array
-                         x-kubernetes-patch-merge-key: name
-                         x-kubernetes-patch-strategy: merge
                        nodeName:
                          description: NodeName indicates in which node this pod is scheduled. If empty, this pod is a candidate for scheduling by the scheduler defined in schedulerName. Once this field is set, the kubelet for this node becomes responsible for the lifecycle of this pod. This field should not be used to express a desire for the pod to be scheduled on a specific node. https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodename
                          type: string
@@ -11820,8 +11732,6 @@ spec:
                              - name
                            type: object
                          type: array
-                         x-kubernetes-patch-merge-key: name
-                         x-kubernetes-patch-strategy: merge,retainKeys
                        resources:
                          description: |-
                            Resources is the total amount of CPU and Memory resources required by all containers in the pod. It supports specifying Requests and Limits for "cpu", "memory" and "hugepages-" resource names only. ResourceClaims are not supported.
@@ -11893,8 +11803,6 @@ spec:
                              - name
                            type: object
                          type: array
-                         x-kubernetes-patch-merge-key: name
-                         x-kubernetes-patch-strategy: merge
                        securityContext:
                          description: "SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field."
                          properties:
@@ -12222,8 +12130,6 @@ spec:
                              - whenUnsatisfiable
                            type: object
                          type: array
-                         x-kubernetes-patch-merge-key: topologyKey
-                         x-kubernetes-patch-strategy: merge
                        volumes:
                          description: "List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes"
                          items:
@@ -12544,7 +12450,6 @@ spec:
                                            items:
                                              type: string
                                            type: array
-                                           x-kubernetes-patch-strategy: merge
                                          generateName:
                                            description: |-
                                              GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
@@ -12629,8 +12534,6 @@ spec:
                                              type: object
                                              x-kubernetes-map-type: atomic
                                            type: array
-                                           x-kubernetes-patch-merge-key: uid
-                                           x-kubernetes-patch-strategy: merge
                                          resourceVersion:
                                            description: |-
                                              An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
@@ -13499,8 +13402,6 @@ spec:
                              - name
                            type: object
                          type: array
-                         x-kubernetes-patch-merge-key: name
-                         x-kubernetes-patch-strategy: merge,retainKeys
                        workloadRef:
                          description: WorkloadRef provides a reference to the Workload object that this Pod belongs to. This field is used by the scheduler to identify the PodGroup and apply the correct group scheduling policies. The Workload object referenced by this field may not exist at the time the Pod is created. This field is immutable, but a Workload object with the same name may be recreated with different policies. Doing this during pod scheduling may result in the placement not conforming to the expected policies.
                          properties:
@@ -14061,7 +13962,6 @@ spec:
                           items:
                             type: string
                           type: array
-                          x-kubernetes-patch-strategy: merge
                         generateName:
                           description: |-
                             GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
@@ -14146,8 +14046,6 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           type: array
-                          x-kubernetes-patch-merge-key: uid
-                          x-kubernetes-patch-strategy: merge
                         resourceVersion:
                           description: |-
                             An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
@@ -14206,7 +14104,6 @@ spec:
                                   items:
                                     type: string
                                   type: array
-                                  x-kubernetes-patch-strategy: merge
                                 generateName:
                                   description: |-
                                     GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
@@ -14291,8 +14188,6 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   type: array
-                                  x-kubernetes-patch-merge-key: uid
-                                  x-kubernetes-patch-strategy: merge
                                 resourceVersion:
                                   description: |-
                                     An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
@@ -14994,8 +14889,6 @@ spec:
                                             - name
                                           type: object
                                         type: array
-                                        x-kubernetes-patch-merge-key: name
-                                        x-kubernetes-patch-strategy: merge
                                       envFrom:
                                         description: List of sources to populate environment variables in the container. The keys defined within a source may consist of any printable ASCII characters except '='. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                         items:
@@ -15484,8 +15377,6 @@ spec:
                                             - containerPort
                                           type: object
                                         type: array
-                                        x-kubernetes-patch-merge-key: containerPort
-                                        x-kubernetes-patch-strategy: merge
                                       readinessProbe:
                                         description: "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
                                         properties:
@@ -15951,8 +15842,6 @@ spec:
                                             - devicePath
                                           type: object
                                         type: array
-                                        x-kubernetes-patch-merge-key: devicePath
-                                        x-kubernetes-patch-strategy: merge
                                       volumeMounts:
                                         description: Pod volumes to mount into the container's filesystem. Cannot be updated.
                                         items:
@@ -16002,8 +15891,6 @@ spec:
                                             - mountPath
                                           type: object
                                         type: array
-                                        x-kubernetes-patch-merge-key: mountPath
-                                        x-kubernetes-patch-strategy: merge
                                       workingDir:
                                         description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                         type: string
@@ -16011,8 +15898,6 @@ spec:
                                       - name
                                     type: object
                                   type: array
-                                  x-kubernetes-patch-merge-key: name
-                                  x-kubernetes-patch-strategy: merge
                                 dnsConfig:
                                   description: Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.
                                   properties:
@@ -16174,8 +16059,6 @@ spec:
                                             - name
                                           type: object
                                         type: array
-                                        x-kubernetes-patch-merge-key: name
-                                        x-kubernetes-patch-strategy: merge
                                       envFrom:
                                         description: List of sources to populate environment variables in the container. The keys defined within a source may consist of any printable ASCII characters except '='. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                         items:
@@ -16664,8 +16547,6 @@ spec:
                                             - containerPort
                                           type: object
                                         type: array
-                                        x-kubernetes-patch-merge-key: containerPort
-                                        x-kubernetes-patch-strategy: merge
                                       readinessProbe:
                                         description: Probes are not allowed for ephemeral containers.
                                         properties:
@@ -17137,8 +17018,6 @@ spec:
                                             - devicePath
                                           type: object
                                         type: array
-                                        x-kubernetes-patch-merge-key: devicePath
-                                        x-kubernetes-patch-strategy: merge
                                       volumeMounts:
                                         description: Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers. Cannot be updated.
                                         items:
@@ -17188,8 +17067,6 @@ spec:
                                             - mountPath
                                           type: object
                                         type: array
-                                        x-kubernetes-patch-merge-key: mountPath
-                                        x-kubernetes-patch-strategy: merge
                                       workingDir:
                                         description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                         type: string
@@ -17197,8 +17074,6 @@ spec:
                                       - name
                                     type: object
                                   type: array
-                                  x-kubernetes-patch-merge-key: name
-                                  x-kubernetes-patch-strategy: merge
                                 hostAliases:
                                   description: HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
                                   items:
@@ -17215,8 +17090,6 @@ spec:
                                       - ip
                                     type: object
                                   type: array
-                                  x-kubernetes-patch-merge-key: ip
-                                  x-kubernetes-patch-strategy: merge
                                 hostIPC:
                                   description: "Use the host's ipc namespace. Optional: Default to false."
                                   type: boolean
@@ -17248,8 +17121,6 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   type: array
-                                  x-kubernetes-patch-merge-key: name
-                                  x-kubernetes-patch-strategy: merge
                                 initContainers:
                                   description: "List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/"
                                   items:
@@ -17367,8 +17238,6 @@ spec:
                                             - name
                                           type: object
                                         type: array
-                                        x-kubernetes-patch-merge-key: name
-                                        x-kubernetes-patch-strategy: merge
                                       envFrom:
                                         description: List of sources to populate environment variables in the container. The keys defined within a source may consist of any printable ASCII characters except '='. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                         items:
@@ -17857,8 +17726,6 @@ spec:
                                             - containerPort
                                           type: object
                                         type: array
-                                        x-kubernetes-patch-merge-key: containerPort
-                                        x-kubernetes-patch-strategy: merge
                                       readinessProbe:
                                         description: "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
                                         properties:
@@ -18324,8 +18191,6 @@ spec:
                                             - devicePath
                                           type: object
                                         type: array
-                                        x-kubernetes-patch-merge-key: devicePath
-                                        x-kubernetes-patch-strategy: merge
                                       volumeMounts:
                                         description: Pod volumes to mount into the container's filesystem. Cannot be updated.
                                         items:
@@ -18375,8 +18240,6 @@ spec:
                                             - mountPath
                                           type: object
                                         type: array
-                                        x-kubernetes-patch-merge-key: mountPath
-                                        x-kubernetes-patch-strategy: merge
                                       workingDir:
                                         description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                         type: string
@@ -18384,8 +18247,6 @@ spec:
                                       - name
                                     type: object
                                   type: array
-                                  x-kubernetes-patch-merge-key: name
-                                  x-kubernetes-patch-strategy: merge
                                 nodeName:
                                   description: NodeName indicates in which node this pod is scheduled. If empty, this pod is a candidate for scheduling by the scheduler defined in schedulerName. Once this field is set, the kubelet for this node becomes responsible for the lifecycle of this pod. This field should not be used to express a desire for the pod to be scheduled on a specific node. https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodename
                                   type: string
@@ -18475,8 +18336,6 @@ spec:
                                       - name
                                     type: object
                                   type: array
-                                  x-kubernetes-patch-merge-key: name
-                                  x-kubernetes-patch-strategy: merge,retainKeys
                                 resources:
                                   description: |-
                                     Resources is the total amount of CPU and Memory resources required by all containers in the pod. It supports specifying Requests and Limits for "cpu", "memory" and "hugepages-" resource names only. ResourceClaims are not supported.
@@ -18548,8 +18407,6 @@ spec:
                                       - name
                                     type: object
                                   type: array
-                                  x-kubernetes-patch-merge-key: name
-                                  x-kubernetes-patch-strategy: merge
                                 securityContext:
                                   description: "SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field."
                                   properties:
@@ -18877,8 +18734,6 @@ spec:
                                       - whenUnsatisfiable
                                     type: object
                                   type: array
-                                  x-kubernetes-patch-merge-key: topologyKey
-                                  x-kubernetes-patch-strategy: merge
                                 volumes:
                                   description: "List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes"
                                   items:
@@ -19199,7 +19054,6 @@ spec:
                                                     items:
                                                       type: string
                                                     type: array
-                                                    x-kubernetes-patch-strategy: merge
                                                   generateName:
                                                     description: |-
                                                       GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
@@ -19284,8 +19138,6 @@ spec:
                                                       type: object
                                                       x-kubernetes-map-type: atomic
                                                     type: array
-                                                    x-kubernetes-patch-merge-key: uid
-                                                    x-kubernetes-patch-strategy: merge
                                                   resourceVersion:
                                                     description: |-
                                                       An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
@@ -20154,8 +20006,6 @@ spec:
                                       - name
                                     type: object
                                   type: array
-                                  x-kubernetes-patch-merge-key: name
-                                  x-kubernetes-patch-strategy: merge,retainKeys
                                 workloadRef:
                                   description: WorkloadRef provides a reference to the Workload object that this Pod belongs to. This field is used by the scheduler to identify the PodGroup and apply the correct group scheduling policies. The Workload object referenced by this field may not exist at the time the Pod is created. This field is immutable, but a Workload object with the same name may be recreated with different policies. Doing this during pod scheduling may result in the placement not conforming to the expected policies.
                                   properties:

--- a/site/content/en/docs/Installation/Install Agones/helm.md
+++ b/site/content/en/docs/Installation/Install Agones/helm.md
@@ -105,11 +105,21 @@ The following tables lists the configurable parameters of the Agones chart and t
 
 ### Custom Resource Definitions
 
+{{% feature expiryVersion="1.61.0" %}}
 | Parameter                     | Description                                                                                                                                                                                                                         | Default |
 | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
 | `agones.crds.install`         | Install the CRDs with this chart. Useful to disable if you want to subchart (since crd-install hook is broken), so you can copy the CRDs into your own chart.                                                                       | `true`  |
 | `agones.crds.cleanupOnDelete` | Run the pre-delete hook to delete all GameServers and their backing Pods when deleting the helm chart, so that all CRDs can be removed on chart deletion                                                                            | `true`  |
 | `agones.crds.cleanupJobTTL`   | The number of seconds for Kubernetes to delete the associated Job and Pods of the pre-delete hook after it completes, regardless if the Job is successful or not. Set to `0` to disable cleaning up the Job or the associated Pods. | `60`    |
+{{% /feature %}}
+{{% feature publishVersion="1.61.0" %}}
+| Parameter                                | Description                                                                                                                                                                                                                         | Default |
+| ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `agones.crds.install`                    | Install the CRDs with this chart. Useful to disable if you want to subchart (since crd-install hook is broken), so you can copy the CRDs into your own chart.                                                                       | `true`  |
+| `agones.crds.cleanupOnDelete`            | Run the pre-delete hook to delete all GameServers and their backing Pods when deleting the helm chart, so that all CRDs can be removed on chart deletion                                                                            | `true`  |
+| `agones.crds.cleanupJobTTL`              | The number of seconds for Kubernetes to delete the associated Job and Pods of the pre-delete hook after it completes, regardless if the Job is successful or not. Set to `0` to disable cleaning up the Job or the associated Pods. | `60`    |
+| `agones.crds.includeKubernetesPatchKeys` | Include the `x-kubernetes-patch-strategy` and `x-kubernetes-patch-merge-key` fields in the embedded `PodTemplateSpec` and `ObjectMeta` CRD schemas. These are not valid CustomResourceDefinition fields, so enabling this produces `unknown field` warnings on install, and fails on Kubernetes distributions that decode strictly, such as K3s. Tools such as [Kustomize][kustomize-openapi] can make use of them. | `false` |
+{{% /feature %}}
 
 ### Metrics
 
@@ -417,6 +427,7 @@ The following tables lists the configurable parameters of the Agones chart and t
 [rest-requests]: {{< ref "/docs/Advanced/allocator-service.md#using-rest" >}}
 [grpc-requests]: {{< ref "/docs/Advanced/allocator-service.md#using-grpc" >}}
 [split-controller]: {{< ref "/docs/Advanced/high-availability-agones" >}}
+[kustomize-openapi]: https://github.com/kubernetes-sigs/kustomize/blob/master/examples/customOpenAPIschema.md
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/agones-dev/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/agones-dev/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/agones-dev/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>

/kind breaking

> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

`x-kubernetes-patch-strategy` and `x-kubernetes-patch-merge-key` are not valid CustomResourceDefinition schema fields, so preserving them in the embedded PodTemplateSpec and ObjectMeta schemas produces "unknown field" warnings on every install, and outright fails on Kubernetes distributions that decode strictly, such as K3s.

Rather than reverting, k8s-export-openapi now wraps each run of those keys in a `{{- if .includeKubernetesPatchKeys }}` conditional, driven by the new `agones.crds.includeKubernetesPatchKeys` value, which defaults to false. A default install is warning-free, while tools that make use of the fields, such as Kustomize, can opt back in.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
Use "Work on #<issue number>" if you wish to reference the issue without closing it.
-->
Closes #4670

**Did you use AI tools in preparing this PR?**:
<!--
If you used AI tools in preparing your PR, you must disclose this in the description of your PR.
--->
Y

**Special notes for your reviewer**:

N/A
