### PR TITLE
Clamp active GameServerSet replicas at zero during fleet rolling updates

### DIFF
--- a/pkg/fleets/controller.go
+++ b/pkg/fleets/controller.go
@@ -519,9 +519,11 @@ func (c *Controller) rollingUpdateActive(fleet *agonesv1.Fleet, active *agonesv1
 	}
 
 	// if the active spec replicas are greater than or equal the fleet spec replicas, then we don't
-	// need to do another rolling update upwards.
+	// need to do another rolling update upwards. Clamp at zero: when the Allocated GameServers in
+	// the inactive GameServerSets outnumber the fleet's target, this subtraction goes negative and
+	// the resulting GameServerSet update is rejected by the API server, aborting every fleet sync.
 	if active.Spec.Replicas >= (fleet.Spec.Replicas - sumAllocated) {
-		return fleet.Spec.Replicas - sumAllocated, nil
+		return fleet.LowerBoundReplicas(fleet.Spec.Replicas - sumAllocated), nil
 	}
 
 	r, err := intstr.GetValueFromIntOrPercent(fleet.Spec.Strategy.RollingUpdate.MaxSurge, int(fleet.Spec.Replicas), true)

--- a/pkg/fleets/controller_test.go
+++ b/pkg/fleets/controller_test.go
@@ -1324,6 +1324,57 @@ func TestControllerRollingUpdateDeploymentNegativeReplica(t *testing.T) {
 	assert.Equal(t, int32(0), replicas)
 }
 
+func TestControllerRollingUpdateDeploymentAllocatedExceedsFleetReplicas(t *testing.T) {
+	t.Parallel()
+
+	// A fleet whose target is below the number of Allocated GameServers still held by an
+	// inactive GameServerSet: the fleet was scaled down (autoscaler or manual) part way
+	// through a rolling update while allocations kept climbing.
+	f := defaultFixture()
+	f.Spec.Replicas = 5
+	f.Status.Replicas = 8
+	f.Status.AllocatedReplicas = 8
+	f.Status.ReadyReplicas = 0
+
+	f.Spec.Template.Spec.Ports = []agonesv1.GameServerPort{{
+		ContainerPort: 6000,
+		Name:          "gameport",
+		PortPolicy:    agonesv1.Dynamic,
+		Protocol:      corev1.ProtocolUDP,
+	}}
+
+	// The inactive set holds 8 Allocated GameServers, 3 more than the whole fleet now wants.
+	inactive := f.GameServerSet()
+	inactive.ObjectMeta.Name = "inactive"
+	inactive.Spec.Replicas = 0
+	inactive.Status.Replicas = 8
+	inactive.Status.ReadyReplicas = 0
+	inactive.Status.AllocatedReplicas = 8
+
+	active := f.GameServerSet()
+	active.ObjectMeta.Name = "active"
+	active.Spec.Replicas = 0
+	active.Status.Replicas = 0
+	active.Status.ReadyReplicas = 0
+	active.Status.AllocatedReplicas = 0
+
+	c, m := newFakeController()
+
+	m.AgonesClient.AddReactor("update", "gameserversets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		ca := action.(k8stesting.UpdateAction)
+		gsSet := ca.GetObject().(*agonesv1.GameServerSet)
+		assert.GreaterOrEqual(t, gsSet.Spec.Replicas, int32(0), "GameServerSet %s was given negative replicas", gsSet.ObjectMeta.Name)
+		return true, gsSet, nil
+	})
+
+	// Without the clamp this returns 5 - 8 = -3, the API server rejects the update
+	// ("spec.replicas ... should be a non-negative integer") and every subsequent fleet
+	// sync aborts until the allocations drain.
+	replicas, err := c.rollingUpdateDeployment(context.Background(), f, active, []*agonesv1.GameServerSet{inactive})
+	assert.NoError(t, err)
+	assert.Equal(t, int32(0), replicas)
+}
+
 func TestControllerRollingUpdateDeploymentGSSUpdateFailedErrExpected(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / Why we need it**:

`rollingUpdateActive` returns `fleet.Spec.Replicas - sumAllocated` unclamped. When the Allocated GameServers held by inactive GameServerSets outnumber the fleet's target replicas (a fleet scaled down, manually or by a FleetAutoscaler, while a rolling update is in flight), that value is negative. The controller submits it as the active GameServerSet's `spec.replicas`, the API server rejects the update (`spec.replicas: Invalid value: -N: should be a non-negative integer`), and `syncFleet` aborts wholesale on every resync. While the loop runs, the fleet does not reconcile at all: no GameServers are created, the Ready buffer cannot recover, and FleetAutoscaler scale-ups are ignored. It self-heals only when enough allocations drain.

This PR clamps the value with the existing `fleet.LowerBoundReplicas` helper, as the neighbouring branches in `applyDeploymentStrategy` and the surge path below already do, and adds a regression test that reproduces the negative value (-3) on the current code.

#2509 / #2623 fixed the `fleet.Spec.Replicas == 0` special case of this arithmetic; this is the same bug for any positive target smaller than the allocated count.

**Which issue(s) this PR fixes**:

Closes #4705

**Special notes for your reviewer**:

Hit in production on Agones 1.46.0 during a load test (rolling update dispatched while ~28 GameServers were Allocated against a fleet target of 10); the code is unchanged on main. The new test fails on current main with `expected: 0, actual: -3` and passes with the fix. Callers were checked: the return value of `rollingUpdateActive` flows only into the active GameServerSet's `spec.replicas`, so nothing depends on a negative value.

**AI Policy**

AI helped drive the diagnosis but was fixed manually