### PR TITLE
Retry TCP dial in SendTCP only on GKE Autopilot

### DIFF
--- a/pkg/cloudproduct/cloudproduct.go
+++ b/pkg/cloudproduct/cloudproduct.go
@@ -60,8 +60,10 @@ const (
 	// If --cloud-product=auto, auto-detect
 	autoDetectString = "auto"
 
-	genericProduct      = "generic"
-	gkeAutopilotProduct = "gke-autopilot"
+	// GenericProduct is a standard Kubernetes cluster.
+	GenericProduct = "generic"
+	// GkeAutopilotProduct is a GKE Autopilot cluster.
+	GkeAutopilotProduct = "gke-autopilot"
 )
 
 var (
@@ -85,9 +87,9 @@ func NewFromFlag(ctx context.Context, kc *kubernetes.Clientset) (ControllerHooks
 	product := autoDetect(ctx, viper.GetString(cloudProductFlag), kc)
 
 	switch product {
-	case gkeAutopilotProduct:
+	case GkeAutopilotProduct:
 		return gke.Autopilot(), nil
-	case genericProduct:
+	case GenericProduct:
 		return generic.New(), nil
 	}
 	return nil, errors.Errorf("unknown cloud product: %q", product)
@@ -105,6 +107,6 @@ func autoDetect(ctx context.Context, product string, kc *kubernetes.Clientset) s
 			return product
 		}
 	}
-	logger.Infof("Cloud product defaulted to %q", genericProduct)
-	return genericProduct
+	logger.Infof("Cloud product defaulted to %q", GenericProduct)
+	return GenericProduct
 }

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -618,7 +618,7 @@ func (f *Framework) SendUDP(t *testing.T, address, msg string) (string, error) {
 // SendGameServerTCP sends a message to a gameserver and returns its reply
 // finds the first tcp port from the spec to send the message to,
 // returns error if no Ports were allocated
-func SendGameServerTCP(gs *agonesv1.GameServer, msg string) (string, error) {
+func (f *Framework) SendGameServerTCP(gs *agonesv1.GameServer, msg string) (string, error) {
 	if len(gs.Status.Ports) == 0 {
 		return "", errors.New("Empty Ports array")
 	}
@@ -626,7 +626,7 @@ func SendGameServerTCP(gs *agonesv1.GameServer, msg string) (string, error) {
 	// use first tcp port
 	for _, p := range gs.Spec.Ports {
 		if p.Protocol == corev1.ProtocolTCP {
-			return SendGameServerTCPToPort(gs, p.Name, msg)
+			return f.SendGameServerTCPToPort(gs, p.Name, msg)
 		}
 	}
 	return "", errors.New("No TCP ports")
@@ -634,26 +634,54 @@ func SendGameServerTCP(gs *agonesv1.GameServer, msg string) (string, error) {
 
 // SendGameServerTCPToPort sends a message to a gameserver at the named port and returns its reply
 // returns error if no Ports were allocated or a port of the specified name doesn't exist
-func SendGameServerTCPToPort(gs *agonesv1.GameServer, portName string, msg string) (string, error) {
+func (f *Framework) SendGameServerTCPToPort(gs *agonesv1.GameServer, portName string, msg string) (string, error) {
 	if len(gs.Status.Ports) == 0 {
 		return "", errors.New("Empty Ports array")
 	}
 	var port agonesv1.GameServerStatusPort
+	var found bool
 	for _, p := range gs.Status.Ports {
 		if p.Name == portName {
 			port = p
+			found = true
+			break
 		}
 	}
+	if !found {
+		return "", errors.Errorf("port %q not found in GameServer status", portName)
+	}
 	address := fmt.Sprintf("%s:%d", gs.Status.Address, port.Port)
-	return SendTCP(address, msg)
+	return f.SendTCP(address, msg)
 }
 
-// SendTCP sends a message to an address, and returns its reply if
-// it returns one in 30 seconds
-func SendTCP(address, msg string) (string, error) {
-	conn, err := net.Dial("tcp", address)
-	if err != nil {
-		return "", err
+// SendTCP connects to an address and sends it a message, returning the
+// reply. On GKE Autopilot, the initial dial is retried for up to 5 minutes,
+// since the network path (e.g. hostPort NAT/eBPF rules) can take a while to
+// become reachable right after a GameServer transitions to Ready; other
+// cloud products dial once, as they are not known to have this delay. Once
+// connected, the reply must arrive within 30 seconds or this returns an
+// error.
+func (f *Framework) SendTCP(address, msg string) (string, error) {
+	var conn net.Conn
+	if f.CloudProduct == "gke-autopilot" {
+		err := wait.PollUntilContextTimeout(context.Background(), time.Second, 5*time.Minute, true, func(_ context.Context) (bool, error) {
+			var dialErr error
+			conn, dialErr = net.Dial("tcp", address)
+			if dialErr != nil {
+				logrus.WithError(dialErr).WithField("address", address).Info("could not dial TCP address, retrying")
+				return false, nil
+			}
+			return true, nil
+		})
+		if err != nil {
+			return "", errors.Wrap(err, "timed out attempting to dial TCP address")
+		}
+	} else {
+		var err error
+		conn, err = net.Dial("tcp", address)
+		if err != nil {
+			return "", err
+		}
 	}
 
 	if err := conn.SetReadDeadline(time.Now().Add(30 * time.Second)); err != nil {
@@ -667,7 +695,7 @@ func SendTCP(address, msg string) (string, error) {
 	}()
 
 	// writes to the tcp connection
-	_, err = fmt.Fprintln(conn, msg)
+	_, err := fmt.Fprintln(conn, msg)
 	if err != nil {
 		return "", err
 	}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -31,6 +31,7 @@ import (
 	"testing"
 	"time"
 
+	"agones.dev/agones/pkg/cloudproduct"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
@@ -204,7 +205,7 @@ func NewFromFlags() (*Framework, error) {
 	framework.Namespace = viper.GetString(namespaceFlag)
 	framework.CloudProduct = viper.GetString(cloudProductFlag)
 	framework.WaitForState = 5 * time.Minute
-	if framework.CloudProduct == "gke-autopilot" {
+	if framework.CloudProduct == cloudproduct.GkeAutopilotProduct {
 		// Autopilot can take a little while due to autoscaling, be a little liberal.
 		// Keeping it under 10m so we don't get stack track dumps at 10m as unit tests can't be extended past 10m.
 		framework.WaitForState = 8 * time.Minute
@@ -663,10 +664,10 @@ func (f *Framework) SendGameServerTCPToPort(gs *agonesv1.GameServer, portName st
 // error.
 func (f *Framework) SendTCP(address, msg string) (string, error) {
 	var conn net.Conn
-	if f.CloudProduct == "gke-autopilot" {
+	if f.CloudProduct == cloudproduct.GkeAutopilotProduct {
 		err := wait.PollUntilContextTimeout(context.Background(), time.Second, 5*time.Minute, true, func(_ context.Context) (bool, error) {
 			var dialErr error
-			conn, dialErr = net.Dial("tcp", address)
+			conn, dialErr = net.DialTimeout("tcp", address, 10*time.Second)
 			if dialErr != nil {
 				logrus.WithError(dialErr).WithField("address", address).Info("could not dial TCP address, retrying")
 				return false, nil
@@ -678,13 +679,13 @@ func (f *Framework) SendTCP(address, msg string) (string, error) {
 		}
 	} else {
 		var err error
-		conn, err = net.Dial("tcp", address)
+		conn, err = net.DialTimeout("tcp", address, 10*time.Second)
 		if err != nil {
 			return "", err
 		}
 	}
 
-	if err := conn.SetReadDeadline(time.Now().Add(30 * time.Second)); err != nil {
+	if err := conn.SetDeadline(time.Now().Add(30 * time.Second)); err != nil {
 		return "", err
 	}
 

--- a/test/e2e/gameserver_test.go
+++ b/test/e2e/gameserver_test.go
@@ -1093,7 +1093,7 @@ func TestGameServerTcpProtocol(t *testing.T) {
 	readyGs, err := framework.CreateGameServerAndWaitUntilReady(t, framework.Namespace, gs)
 	require.NoError(t, err)
 
-	replyTCP, err := e2eframework.SendGameServerTCP(readyGs, "Hello World !")
+	replyTCP, err := framework.SendGameServerTCP(readyGs, "Hello World !")
 	if err != nil {
 		framework.LogEvents(t, log, readyGs.ObjectMeta.Namespace, readyGs)
 		pod, err := framework.KubeClient.CoreV1().Pods(readyGs.ObjectMeta.Namespace).Get(ctx, readyGs.Name, metav1.GetOptions{})
@@ -1148,7 +1148,7 @@ func TestGameServerTcpUdpProtocol(t *testing.T) {
 
 	logrus.WithField("name", readyGs.ObjectMeta.Name).Info("UDP ping passed, sending TCP ping")
 
-	replyTCP, err := e2eframework.SendGameServerTCPToPort(readyGs, tcpPort.Name, "Hello World !")
+	replyTCP, err := framework.SendGameServerTCPToPort(readyGs, tcpPort.Name, "Hello World !")
 	if err != nil {
 		t.Fatalf("Could not ping TCP GameServer: %v", err)
 	}
@@ -1197,7 +1197,7 @@ func TestGameServerStaticTcpUdpProtocol(t *testing.T) {
 
 	logrus.WithField("name", readyGs.ObjectMeta.Name).Info("UDP ping passed, sending TCP ping")
 
-	replyTCP, err := e2eframework.SendGameServerTCPToPort(readyGs, tcpPort.Name, "Hello World !")
+	replyTCP, err := framework.SendGameServerTCPToPort(readyGs, tcpPort.Name, "Hello World !")
 	if err != nil {
 		t.Fatalf("Could not ping TCP GameServer: %v", err)
 	}
@@ -1224,7 +1224,7 @@ func TestGameServerStaticTcpProtocol(t *testing.T) {
 
 	logrus.WithField("name", readyGs.ObjectMeta.Name).Info("sending TCP ping")
 
-	replyTCP, err := e2eframework.SendGameServerTCP(readyGs, "Hello World !")
+	replyTCP, err := framework.SendGameServerTCP(readyGs, "Hello World !")
 	require.NoError(t, err)
 	assert.Equal(t, "ACK TCP: Hello World !\n", replyTCP)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/agones-dev/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/agones-dev/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/agones-dev/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

PR #4694 fixed the flaky TestGameServerTcpProtocol by retrying the initial net.Dial in SendTCP for up to 15s unconditionally. Per the issue discussion, the flakiness is specific to GKE Autopilot - so this is a replacement PR for that effort that only targets GKE Autopilot and expands the timeout to 5m.

SendTCP, SendGameServerTCP, and SendGameServerTCPToPort are converted from free functions to methods on *Framework (mirroring the existing SendUDP/SendGameServerUDP/SendGameServerUDPToPort pattern) so SendTCP can check f.CloudProduct and retry appropriately for the platform.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
Use "Work on #<issue number>" if you wish to reference the issue without closing it.
-->
Closes #4686

**Did you use AI tools in preparing this PR?**:
<!--
If you used AI tools in preparing your PR, you must disclose this in the description of your PR.
--->
Y

**Special notes for your reviewer**:

Replacement for PR #4694
