### PR TITLE
feat: stop using github.com/pkg/errors in build/*

### DIFF
--- a/build/scripts/previousversion/go.mod
+++ b/build/scripts/previousversion/go.mod
@@ -2,7 +2,4 @@ module github.com/agones/agones/build/scripts/previousversion
 
 go 1.26.5
 
-require (
-	github.com/blang/semver/v4 v4.0.0
-	github.com/pkg/errors v0.9.1
-)
+require github.com/blang/semver/v4 v4.0.0

--- a/build/scripts/previousversion/go.sum
+++ b/build/scripts/previousversion/go.sum
@@ -1,4 +1,2 @@
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/build/scripts/previousversion/main.go
+++ b/build/scripts/previousversion/main.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 
 	semver "github.com/blang/semver/v4"
-	"github.com/pkg/errors"
 )
 
 // gcsLister defines an interface for listing GCS objects, allowing for mocking in tests.
@@ -45,7 +44,7 @@ func (g gsutilLister) List(prefix string) (string, error) {
 	cmd.Stderr = &stderr
 	err := cmd.Run()
 	if err != nil {
-		return "", errors.Errorf("gsutil command failed: %v: %s", err, stderr.String())
+		return "", fmt.Errorf("gsutil command failed: %v: %s", err, stderr.String())
 	}
 	return out.String(), nil
 }

--- a/build/scripts/previousversion/main_test.go
+++ b/build/scripts/previousversion/main_test.go
@@ -15,9 +15,9 @@
 package main
 
 import (
+	"errors"
 	"testing"
 
-	"github.com/pkg/errors"
 	semver "github.com/blang/semver/v4"
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/agones-dev/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/agones-dev/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/agones-dev/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / Why we need it**:

Stop using github.com/pkg/errors in build/*, uses either go std errors or fmt.Errorf when needed, also remove it from go.mod (+ go mod tidy)

**Which issue(s) this PR fixes**:
Work on #4510 

**Did you use AI tools in preparing this PR?**:
Y

**Special notes for your reviewer**:
