### PR TITLE
fix: plumb gameservers.lists.maxItems through to the SDK server

### DIFF
--- a/cmd/allocator/main.go
+++ b/cmd/allocator/main.go
@@ -95,6 +95,7 @@ const (
 	apiServerBurstQPSFlag            = "api-server-qps-burst"
 	logLevelFlag                     = "log-level"
 	allocationBatchWaitTime          = "allocation-batch-wait-time"
+	maxListItemsFlag                 = "max-list-items"
 	readinessShutdownDuration        = "readiness-shutdown-duration"
 	httpUnallocatedStatusCode        = "http-unallocated-status-code"
 	processorGRPCAddress             = "processor-grpc-address"
@@ -117,6 +118,7 @@ func parseEnvFlags() config {
 	viper.SetDefault(totalRemoteAllocationTimeoutFlag, 30*time.Second)
 	viper.SetDefault(logLevelFlag, "Info")
 	viper.SetDefault(allocationBatchWaitTime, 500*time.Millisecond)
+	viper.SetDefault(maxListItemsFlag, 1000)
 	viper.SetDefault(httpUnallocatedStatusCode, http.StatusTooManyRequests)
 	viper.SetDefault(processorGRPCAddress, "agones-processor.agones-system.svc.cluster.local")
 	viper.SetDefault(processorGRPCPort, 9090)
@@ -136,6 +138,7 @@ func parseEnvFlags() config {
 	pflag.Duration(totalRemoteAllocationTimeoutFlag, viper.GetDuration(totalRemoteAllocationTimeoutFlag), "Flag to set total remote allocation timeout including retries.")
 	pflag.String(logLevelFlag, viper.GetString(logLevelFlag), "Agones Log level")
 	pflag.Duration(allocationBatchWaitTime, viper.GetDuration(allocationBatchWaitTime), "Flag to configure the waiting period between allocations batches")
+	pflag.Int64(maxListItemsFlag, viper.GetInt64(maxListItemsFlag), "Flag to set the maximum Capacity a GameServer List may be set to during allocation. Can also use MAX_LIST_ITEMS env variable")
 	pflag.Duration(readinessShutdownDuration, viper.GetDuration(readinessShutdownDuration), "Time in seconds for SIGTERM/SIGINT handler to sleep for.")
 	pflag.Int32(httpUnallocatedStatusCode, viper.GetInt32(httpUnallocatedStatusCode), "HTTP status code to return when no GameServer is available")
 	pflag.String(processorGRPCAddress, viper.GetString(processorGRPCAddress), "The gRPC address of the Agones Processor service")
@@ -160,6 +163,7 @@ func parseEnvFlags() config {
 	runtime.Must(viper.BindEnv(totalRemoteAllocationTimeoutFlag))
 	runtime.Must(viper.BindEnv(logLevelFlag))
 	runtime.Must(viper.BindEnv(allocationBatchWaitTime))
+	runtime.Must(viper.BindEnv(maxListItemsFlag))
 	runtime.Must(viper.BindEnv(readinessShutdownDuration))
 	runtime.Must(viper.BindEnv(httpUnallocatedStatusCode))
 	runtime.Must(viper.BindPFlags(pflag.CommandLine))
@@ -182,6 +186,7 @@ func parseEnvFlags() config {
 		remoteAllocationTimeout:      viper.GetDuration(remoteAllocationTimeoutFlag),
 		totalRemoteAllocationTimeout: viper.GetDuration(totalRemoteAllocationTimeoutFlag),
 		allocationBatchWaitTime:      viper.GetDuration(allocationBatchWaitTime),
+		maxListItems:                 viper.GetInt64(maxListItemsFlag),
 		ReadinessShutdownDuration:    viper.GetDuration(readinessShutdownDuration),
 		httpUnallocatedStatusCode:    int(viper.GetInt32(httpUnallocatedStatusCode)),
 		processorGRPCAddress:         viper.GetString(processorGRPCAddress),
@@ -205,6 +210,7 @@ type config struct {
 	totalRemoteAllocationTimeout time.Duration
 	remoteAllocationTimeout      time.Duration
 	allocationBatchWaitTime      time.Duration
+	maxListItems                 int64
 	ReadinessShutdownDuration    time.Duration
 	httpUnallocatedStatusCode    int
 	processorGRPCAddress         string
@@ -231,6 +237,10 @@ func main() {
 	logger.WithField("version", pkg.Version).WithField("ctlConf", conf).
 		WithField("featureGates", runtime.EncodeFeatures()).
 		Info("Starting agones-allocator")
+
+	if conf.maxListItems <= 0 {
+		logger.Fatalf("%s must be greater than 0", maxListItemsFlag)
+	}
 
 	logger.WithField("logLevel", conf.LogLevel).Info("Setting LogLevel configuration")
 	level, err := logrus.ParseLevel(strings.ToLower(conf.LogLevel))
@@ -318,7 +328,7 @@ func main() {
 		h = newProcessorServiceHandler(processorClient, conf.MTLSDisabled, conf.TLSDisabled)
 	} else {
 		grpcUnallocatedStatusCode := processor.GRPCCodeFromHTTPStatus(conf.httpUnallocatedStatusCode)
-		h = newServiceHandler(workerCtx, kubeClient, agonesClient, health, conf.MTLSDisabled, conf.TLSDisabled, conf.remoteAllocationTimeout, conf.totalRemoteAllocationTimeout, conf.allocationBatchWaitTime, grpcUnallocatedStatusCode)
+		h = newServiceHandler(workerCtx, kubeClient, agonesClient, health, conf.MTLSDisabled, conf.TLSDisabled, conf.remoteAllocationTimeout, conf.totalRemoteAllocationTimeout, conf.allocationBatchWaitTime, grpcUnallocatedStatusCode, conf.maxListItems)
 	}
 
 	if !h.tlsDisabled {
@@ -515,7 +525,7 @@ func newProcessorServiceHandler(processorClient processor.Client, mTLSDisabled, 
 	return &h
 }
 
-func newServiceHandler(ctx context.Context, kubeClient kubernetes.Interface, agonesClient versioned.Interface, health healthcheck.Handler, mTLSDisabled bool, tlsDisabled bool, remoteAllocationTimeout time.Duration, totalRemoteAllocationTimeout time.Duration, allocationBatchWaitTime time.Duration, grpcUnallocatedStatusCode codes.Code) *serviceHandler {
+func newServiceHandler(ctx context.Context, kubeClient kubernetes.Interface, agonesClient versioned.Interface, health healthcheck.Handler, mTLSDisabled bool, tlsDisabled bool, remoteAllocationTimeout time.Duration, totalRemoteAllocationTimeout time.Duration, allocationBatchWaitTime time.Duration, grpcUnallocatedStatusCode codes.Code, listMaxCapacity int64) *serviceHandler {
 	defaultResync := 30 * time.Second
 	agonesInformerFactory := externalversions.NewSharedInformerFactory(agonesClient, defaultResync)
 	kubeInformerFactory := informers.NewSharedInformerFactory(kubeClient, defaultResync)
@@ -529,7 +539,8 @@ func newServiceHandler(ctx context.Context, kubeClient kubernetes.Interface, ago
 		gameserverallocations.NewAllocationCache(agonesInformerFactory.Agones().V1().GameServers(), gsCounter, health),
 		remoteAllocationTimeout,
 		totalRemoteAllocationTimeout,
-		allocationBatchWaitTime)
+		allocationBatchWaitTime,
+		listMaxCapacity)
 
 	h := serviceHandler{
 		allocationCallback: func(allocationCtx context.Context, gsa *allocationv1.GameServerAllocation) (k8sruntime.Object, error) {

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -527,7 +527,7 @@ func (c *config) validate() []error {
 	resourceErrors = validateResource(c.SidecarMemoryRequest, c.SidecarMemoryLimit, corev1.ResourceMemory)
 	validationErrors = append(validationErrors, resourceErrors...)
 	if c.MaxListItems <= 0 {
-		validationErrors = append(validationErrors, errors.Errorf("%s must be greater than 0", maxListItemsFlag))
+		validationErrors = append(validationErrors, errs.Errorf("%s must be greater than 0", maxListItemsFlag))
 	}
 	return validationErrors
 }

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -92,6 +92,7 @@ const (
 	maxDeletionParallelismFlag         = "max-deletion-parallelism"
 	maxGameServerDeletionsPerBatchFlag = "max-game-server-deletions-per-batch"
 	maxPodPendingCountFlag             = "max-pod-pending-count"
+	maxListItemsFlag                   = "max-list-items"
 )
 
 var (
@@ -208,7 +209,8 @@ func main() {
 	gsController := gameservers.NewController(controllerHooks, health,
 		ctlConf.PortRanges, ctlConf.SidecarImage, ctlConf.AlwaysPullSidecar,
 		ctlConf.SidecarCPURequest, ctlConf.SidecarCPULimit,
-		ctlConf.SidecarMemoryRequest, ctlConf.SidecarMemoryLimit, ctlConf.SidecarSecurityContext, ctlConf.SidecarRequestsRateLimit, ctlConf.SdkServiceAccount,
+		ctlConf.SidecarMemoryRequest, ctlConf.SidecarMemoryLimit, ctlConf.SidecarSecurityContext, ctlConf.SidecarRequestsRateLimit,
+		ctlConf.MaxListItems, ctlConf.SdkServiceAccount,
 		kubeClient, kubeInformerFactory, extClient, agonesClient, agonesInformerFactory)
 	gsSetController := gameserversets.NewController(health, gsCounter,
 		kubeClient, extClient, agonesClient, agonesInformerFactory, ctlConf.MaxCreationParallelism, ctlConf.MaxDeletionParallelism, ctlConf.MaxGameServerCreationsPerBatch, ctlConf.MaxGameServerDeletionsPerBatch, ctlConf.MaxPodPendingCount)
@@ -281,6 +283,7 @@ func parseEnvFlags() config {
 	viper.SetDefault(maxDeletionParallelismFlag, 64)
 	viper.SetDefault(maxGameServerDeletionsPerBatchFlag, 64)
 	viper.SetDefault(maxPodPendingCountFlag, 5000)
+	viper.SetDefault(maxListItemsFlag, 1000)
 
 	pflag.String(sidecarImageFlag, viper.GetString(sidecarImageFlag), "Flag to overwrite the GameServer sidecar image that is used. Can also use SIDECAR env variable")
 	pflag.String(sidecarCPULimitFlag, viper.GetString(sidecarCPULimitFlag), "Flag to overwrite the GameServer sidecar container's cpu limit. Can also use SIDECAR_CPU_LIMIT env variable")
@@ -290,6 +293,7 @@ func parseEnvFlags() config {
 	pflag.Int32(sidecarRunAsUserFlag, viper.GetInt32(sidecarRunAsUserFlag), "Flag to indicate the GameServer sidecar container's UID. Only used when --sidecar-security-context is empty. Can also use SIDECAR_RUN_AS_USER env variable")
 	pflag.String(sidecarSecurityContextFlag, viper.GetString(sidecarSecurityContextFlag), `Optional. JSON encoded Kubernetes SecurityContext for the GameServer sidecar container. Defaults to a context compatible with the "restricted" Pod Security Standard. Can also use SIDECAR_SECURITY_CONTEXT env variable`)
 	pflag.String(sidecarRequestsRateLimitFlag, viper.GetString(sidecarRequestsRateLimitFlag), "Flag to indicate the GameServer sidecar requests rate limit. Can also use SIDECAR_REQUESTS_RATE_LIMIT env variable")
+	pflag.Int64(maxListItemsFlag, viper.GetInt64(maxListItemsFlag), "Flag to set the maximum Capacity a GameServer List may be set to, passed on to the SDK sidecar. Can also use MAX_LIST_ITEMS env variable")
 	pflag.Bool(pullSidecarFlag, viper.GetBool(pullSidecarFlag), "For development purposes, set the sidecar image to have a ImagePullPolicy of Always. Can also use ALWAYS_PULL_SIDECAR env variable")
 	pflag.String(sdkServerAccountFlag, viper.GetString(sdkServerAccountFlag), "Overwrite what service account default for GameServer Pods. Defaults to Can also use SDK_SERVICE_ACCOUNT")
 	pflag.Int32(minPortFlag, 0, "Required. The minimum port that that a GameServer can be allocated to. Can also use MIN_PORT env variable.")
@@ -329,6 +333,7 @@ func parseEnvFlags() config {
 	runtime.Must(viper.BindEnv(sidecarRunAsUserFlag))
 	runtime.Must(viper.BindEnv(sidecarSecurityContextFlag))
 	runtime.Must(viper.BindEnv(sidecarRequestsRateLimitFlag))
+	runtime.Must(viper.BindEnv(maxListItemsFlag))
 	runtime.Must(viper.BindEnv(pullSidecarFlag))
 	runtime.Must(viper.BindEnv(sdkServerAccountFlag))
 	runtime.Must(viper.BindEnv(minPortFlag))
@@ -409,6 +414,7 @@ func parseEnvFlags() config {
 		SidecarMemoryLimit:             limitMemory,
 		SidecarSecurityContext:         sidecarSecurityContext,
 		SidecarRequestsRateLimit:       requestsRateLimit,
+		MaxListItems:                   viper.GetInt64(maxListItemsFlag),
 		SdkServiceAccount:              viper.GetString(sdkServerAccountFlag),
 		AlwaysPullSidecar:              viper.GetBool(pullSidecarFlag),
 		KeyFile:                        viper.GetString(keyFileFlag),
@@ -485,6 +491,7 @@ type config struct {
 	SidecarMemoryLimit             resource.Quantity
 	SidecarSecurityContext         *corev1.SecurityContext
 	SidecarRequestsRateLimit       time.Duration
+	MaxListItems                   int64
 	SdkServiceAccount              string
 	AlwaysPullSidecar              bool
 	PrometheusMetrics              bool
@@ -519,6 +526,9 @@ func (c *config) validate() []error {
 	validationErrors = append(validationErrors, resourceErrors...)
 	resourceErrors = validateResource(c.SidecarMemoryRequest, c.SidecarMemoryLimit, corev1.ResourceMemory)
 	validationErrors = append(validationErrors, resourceErrors...)
+	if c.MaxListItems <= 0 {
+		validationErrors = append(validationErrors, errors.Errorf("%s must be greater than 0", maxListItemsFlag))
+	}
 	return validationErrors
 }
 

--- a/cmd/controller/main_test.go
+++ b/cmd/controller/main_test.go
@@ -66,9 +66,12 @@ func TestParseSidecarSecurityContext(t *testing.T) {
 func TestControllerConfigValidation(t *testing.T) {
 	t.Parallel()
 
-	c := config{PortRanges: map[string]portallocator.PortRange{
-		agonesv1.DefaultPortRange: {MinPort: 10, MaxPort: 2},
-	}}
+	c := config{
+		PortRanges: map[string]portallocator.PortRange{
+			agonesv1.DefaultPortRange: {MinPort: 10, MaxPort: 2},
+		},
+		MaxListItems: 1000,
+	}
 	errs := c.validate()
 	assert.Len(t, errs, 1)
 	errorsContainString(t, errs, "max Port cannot be set less that the Min Port")
@@ -108,10 +111,39 @@ func TestControllerConfigValidation_PortRangeOverlap(t *testing.T) {
 			"game":                    {MinPort: 15, MaxPort: 25},
 			"other":                   {MinPort: 21, MaxPort: 31},
 		},
+		MaxListItems: 1000,
 	}
 	errs := c.validate()
 	assert.Len(t, errs, 2)
 	errorsContainString(t, errs, "port range game overlaps with min/max port")
+}
+
+// MAX_LIST_ITEMS is supplied by the Helm chart from gameservers.lists.maxItems, and defaults to 1000
+// when it isn't. An explicitly non-positive value would reject every UpdateList, so it is caught at
+// startup rather than silently passed on to the sidecar.
+func TestControllerConfigValidationMaxListItems(t *testing.T) {
+	t.Parallel()
+
+	validPorts := map[string]portallocator.PortRange{
+		agonesv1.DefaultPortRange: {MinPort: 10, MaxPort: 20},
+	}
+
+	for desc, maxListItems := range map[string]int64{
+		"zero":     0,
+		"negative": -1,
+	} {
+		t.Run(desc, func(t *testing.T) {
+			c := config{PortRanges: validPorts, MaxListItems: maxListItems}
+			errs := c.validate()
+			assert.Len(t, errs, 1)
+			errorsContainString(t, errs, "max-list-items must be greater than 0")
+		})
+	}
+
+	t.Run("set", func(t *testing.T) {
+		c := config{PortRanges: validPorts, MaxListItems: 25}
+		assert.Empty(t, c.validate())
+	})
 }
 
 func errorsContainString(t *testing.T, errs []error, expected string) {

--- a/cmd/extensions/main.go
+++ b/cmd/extensions/main.go
@@ -63,6 +63,7 @@ const (
 	logLevelFlag                 = "log-level"
 	logSizeLimitMBFlag           = "log-size-limit-mb"
 	allocationBatchWaitTime      = "allocation-batch-wait-time"
+	maxListItemsFlag             = "max-list-items"
 	kubeconfigFlag               = "kubeconfig"
 	defaultResync                = 30 * time.Second
 	apiServerSustainedQPSFlag    = "api-server-qps"
@@ -119,6 +120,10 @@ func main() {
 
 	logger.WithField("version", pkg.Version).WithField("featureGates", runtime.EncodeFeatures()).
 		WithField("ctlConf", ctlConf).Info("starting extensions operator...")
+
+	if ctlConf.MaxListItems <= 0 {
+		logger.Fatalf("%s must be greater than 0", maxListItemsFlag)
+	}
 
 	// if the kubeconfig fails InClusterBuildConfig will try in cluster config
 	clientConf, err := runtime.InClusterBuildConfig(logger, ctlConf.KubeConfig)
@@ -223,7 +228,8 @@ func main() {
 		gsCounter := gameservers.NewPerNodeCounter(kubeInformerFactory, agonesInformerFactory)
 
 		gasExtensions = gameserverallocations.NewExtensions(api, health, gsCounter, kubeClient, kubeInformerFactory,
-			agonesClient, agonesInformerFactory, 10*time.Second, 30*time.Second, ctlConf.AllocationBatchWaitTime)
+			agonesClient, agonesInformerFactory, 10*time.Second, 30*time.Second, ctlConf.AllocationBatchWaitTime,
+			ctlConf.MaxListItems)
 
 		kubeInformerFactory.Start(ctx.Done())
 		agonesInformerFactory.Start(ctx.Done())
@@ -271,6 +277,7 @@ func parseEnvFlags() config {
 	viper.SetDefault(logSizeLimitMBFlag, 10000) // 10 GB, will be split into 100 MB chunks
 	viper.SetDefault(httpPort, "8080")
 	viper.SetDefault(webhookPort, "8081")
+	viper.SetDefault(maxListItemsFlag, 1000)
 
 	viper.SetDefault(processorGRPCAddress, "agones-processor.agones-system.svc.cluster.local")
 	viper.SetDefault(processorGRPCPort, 9090)
@@ -294,6 +301,7 @@ func parseEnvFlags() config {
 	pflag.Int32(logSizeLimitMBFlag, 1000, "Log file size limit in MB")
 	pflag.String(logLevelFlag, viper.GetString(logLevelFlag), "Agones Log level")
 	pflag.Duration(allocationBatchWaitTime, viper.GetDuration(allocationBatchWaitTime), "Flag to configure the waiting period between allocations batches")
+	pflag.Int64(maxListItemsFlag, viper.GetInt64(maxListItemsFlag), "Flag to set the maximum Capacity a GameServer List may be set to during allocation. Can also use MAX_LIST_ITEMS env variable")
 	pflag.Duration(readinessShutdownDuration, viper.GetDuration(readinessShutdownDuration), "Time in seconds for SIGTERM handler to sleep for.")
 
 	pflag.String(processorGRPCAddress, viper.GetString(processorGRPCAddress), "The gRPC address of the Agones Processor service")
@@ -324,6 +332,7 @@ func parseEnvFlags() config {
 	runtime.Must(viper.BindEnv(httpPort))
 	runtime.Must(viper.BindEnv(webhookPort))
 	runtime.Must(viper.BindEnv(allocationBatchWaitTime))
+	runtime.Must(viper.BindEnv(maxListItemsFlag))
 	runtime.Must(viper.BindPFlags(pflag.CommandLine))
 	runtime.Must(viper.BindEnv(readinessShutdownDuration))
 	runtime.Must(cloudproduct.BindEnv())
@@ -349,6 +358,7 @@ func parseEnvFlags() config {
 		HTTPPort:                  viper.GetString(httpPort),
 		WebhookPort:               viper.GetString(webhookPort),
 		AllocationBatchWaitTime:   viper.GetDuration(allocationBatchWaitTime),
+		MaxListItems:              viper.GetInt64(maxListItemsFlag),
 		ReadinessShutdownDuration: viper.GetDuration(readinessShutdownDuration),
 
 		processorGRPCAddress:  viper.GetString(processorGRPCAddress),
@@ -377,6 +387,7 @@ type config struct {
 	HTTPPort                  string
 	WebhookPort               string
 	AllocationBatchWaitTime   time.Duration
+	MaxListItems              int64
 	ReadinessShutdownDuration time.Duration
 
 	processorGRPCAddress  string

--- a/cmd/processor/main.go
+++ b/cmd/processor/main.go
@@ -55,6 +55,7 @@ import (
 
 const (
 	allocationBatchWaitTime          = "allocation-batch-wait-time"
+	maxListItemsFlag                 = "max-list-items"
 	apiServerBurstQPSFlag            = "api-server-qps-burst"
 	apiServerSustainedQPSFlag        = "api-server-qps"
 	defaultResync                    = 30 * time.Second
@@ -93,6 +94,7 @@ type processorConfig struct {
 	PrometheusMetrics            bool
 	Stackdriver                  bool
 	AllocationBatchWaitTime      time.Duration
+	MaxListItems                 int64
 	LeaseDuration                time.Duration
 	PullInterval                 time.Duration
 	RenewDeadline                time.Duration
@@ -112,6 +114,7 @@ func parseEnvFlags() processorConfig {
 	viper.SetDefault(leaderElectionFlag, false)
 	viper.SetDefault(leaseDurationFlag, 15*time.Second)
 	viper.SetDefault(logLevelFlag, "Info")
+	viper.SetDefault(maxListItemsFlag, 1000)
 	viper.SetDefault(podNamespace, "")
 	viper.SetDefault(projectIDFlag, "")
 	viper.SetDefault(pullIntervalFlag, 200*time.Millisecond)
@@ -122,6 +125,7 @@ func parseEnvFlags() processorConfig {
 	viper.SetDefault(totalRemoteAllocationTimeoutFlag, 30*time.Second)
 
 	pflag.Duration(allocationBatchWaitTime, viper.GetDuration(allocationBatchWaitTime), "Flag to configure the waiting period between allocations batches")
+	pflag.Int64(maxListItemsFlag, viper.GetInt64(maxListItemsFlag), "Flag to set the maximum Capacity a GameServer List may be set to during allocation. Can also use MAX_LIST_ITEMS env variable")
 	pflag.Int32(apiServerBurstQPSFlag, viper.GetInt32(apiServerBurstQPSFlag), "Maximum burst queries per second to send to the API server")
 	pflag.Int32(apiServerSustainedQPSFlag, viper.GetInt32(apiServerSustainedQPSFlag), "Maximum sustained queries per second to send to the API server")
 	pflag.Bool(enablePrometheusMetricsFlag, viper.GetBool(enablePrometheusMetricsFlag), "Flag to activate metrics of Agones. Can also use PROMETHEUS_EXPORTER env variable.")
@@ -143,6 +147,7 @@ func parseEnvFlags() processorConfig {
 
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	runtime.Must(viper.BindEnv(allocationBatchWaitTime))
+	runtime.Must(viper.BindEnv(maxListItemsFlag))
 	runtime.Must(viper.BindEnv(apiServerBurstQPSFlag))
 	runtime.Must(viper.BindEnv(apiServerSustainedQPSFlag))
 	runtime.Must(viper.BindEnv(enablePrometheusMetricsFlag))
@@ -166,6 +171,7 @@ func parseEnvFlags() processorConfig {
 
 	return processorConfig{
 		AllocationBatchWaitTime:      viper.GetDuration(allocationBatchWaitTime),
+		MaxListItems:                 viper.GetInt64(maxListItemsFlag),
 		APIServerBurstQPS:            int(viper.GetInt32(apiServerBurstQPSFlag)),
 		APIServerSustainedQPS:        int(viper.GetInt32(apiServerSustainedQPSFlag)),
 		GCPProjectID:                 viper.GetString(projectIDFlag),
@@ -195,6 +201,10 @@ func main() {
 	logger.WithField("version", pkg.Version).WithField("processorConf", conf).
 		WithField("featureGates", runtime.EncodeFeatures()).
 		Info("Starting agones-processor")
+
+	if conf.MaxListItems <= 0 {
+		logger.Fatalf("%s must be greater than 0", maxListItemsFlag)
+	}
 
 	logger.WithField("logLevel", conf.LogLevel).Info("Setting LogLevel configuration")
 	level, err := logrus.ParseLevel(strings.ToLower(conf.LogLevel))
@@ -236,7 +246,8 @@ func main() {
 		gameserverallocations.NewAllocationCache(agonesInformerFactory.Agones().V1().GameServers(), gsCounter, health),
 		conf.RemoteAllocationTimeout,
 		conf.TotalRemoteAllocationTimeout,
-		conf.AllocationBatchWaitTime)
+		conf.AllocationBatchWaitTime,
+		conf.MaxListItems)
 	kubeInformerFactory.Start(ctx.Done())
 	agonesInformerFactory.Start(ctx.Done())
 	if err := allocator.Run(ctx); err != nil {

--- a/cmd/sdk-server/main.go
+++ b/cmd/sdk-server/main.go
@@ -51,6 +51,8 @@ const (
 	defaultHTTPPort   = 9358
 	defaultHealthPort = 8080
 
+	defaultMaxListItems = 1000
+
 	// readHeaderTimeout bounds how long a client may take to send its request
 	// headers, so a Slowloris client cannot hold the listener open indefinitely.
 	readHeaderTimeout = 60 * time.Second
@@ -71,7 +73,8 @@ const (
 	httpPortFlag            = "http-port"
 	healthPortFlag          = "health-port"
 	logLevelFlag            = "log-level"
-	requestRateLimitFlag    = "request-rate-limit"
+	requestsRateLimitFlag   = "requests-rate-limit"
+	maxListItemsFlag        = "max-list-items"
 )
 
 var (
@@ -89,6 +92,10 @@ func main() {
 	logger.Logger.SetLevel(logLevel)
 	logger.WithField("version", pkg.Version).WithField("featureGates", runtime.EncodeFeatures()).
 		WithField("ctlConf", ctlConf).Info("Starting sdk sidecar")
+
+	if ctlConf.MaxListItems <= 0 {
+		logger.Fatalf("%s must be greater than 0", maxListItemsFlag)
+	}
 
 	if ctlConf.Delay > 0 {
 		logger.Infof("Waiting %d seconds before starting", ctlConf.Delay)
@@ -156,7 +163,8 @@ func main() {
 
 		var s *sdkserver.SDKServer
 		s, err = sdkserver.NewSDKServer(ctlConf.GameServerName, ctlConf.PodNamespace,
-			kubeClient, agonesClient, logLevel, ctlConf.HealthPort, ctlConf.RequestsRateLimit)
+			kubeClient, agonesClient, logLevel, ctlConf.HealthPort, ctlConf.RequestsRateLimit,
+			ctlConf.MaxListItems)
 		if err != nil {
 			logger.WithError(err).Fatalf("Could not start sidecar")
 		}
@@ -206,7 +214,7 @@ func registerLocal(grpcServer *grpc.Server, ctlConf config) (func(), error) {
 		}
 	}
 
-	s, err := sdkserver.NewLocalSDKServer(filePath, ctlConf.TestSdkName)
+	s, err := sdkserver.NewLocalSDKServer(filePath, ctlConf.TestSdkName, ctlConf.MaxListItems)
 	if err != nil {
 		return nil, err
 	}
@@ -223,7 +231,7 @@ func registerLocal(grpcServer *grpc.Server, ctlConf config) (func(), error) {
 // registerLocal registers the local test SDK servers, and returns a cancel func that
 // closes all the SDK implementations
 func registerTestSdkServer(grpcServer *grpc.Server, ctlConf config) (func(), error) {
-	s, err := sdkserver.NewLocalSDKServer("", "")
+	s, err := sdkserver.NewLocalSDKServer("", "", ctlConf.MaxListItems)
 	if err != nil {
 		return nil, err
 	}
@@ -301,7 +309,8 @@ func parseEnvFlags() config {
 	viper.SetDefault(httpPortFlag, defaultHTTPPort)
 	viper.SetDefault(healthPortFlag, defaultHealthPort)
 	viper.SetDefault(logLevelFlag, "Info")
-	viper.SetDefault(requestRateLimitFlag, "500ms")
+	viper.SetDefault(requestsRateLimitFlag, "500ms")
+	viper.SetDefault(maxListItemsFlag, defaultMaxListItems)
 	pflag.String(gameServerNameFlag, viper.GetString(gameServerNameFlag),
 		"Optional flag to set GameServer name. Overrides value given from `GAMESERVER_NAME` environment variable.")
 	pflag.String(podNamespaceFlag, viper.GetString(gameServerNameFlag),
@@ -321,7 +330,8 @@ func parseEnvFlags() config {
 		"Optional. kubeconfig to run the SDK server out of the cluster.")
 	pflag.Bool(gracefulTerminationFlag, viper.GetBool(gracefulTerminationFlag),
 		"When false, immediately quits when receiving interrupt instead of waiting for GameServer state to progress to \"Shutdown\".")
-	pflag.String(requestRateLimitFlag, viper.GetString(requestRateLimitFlag), "Time to delay between requests to the API server. Defaults to 500ms.")
+	pflag.String(requestsRateLimitFlag, viper.GetString(requestsRateLimitFlag), "Time to delay between requests to the API server. Defaults to 500ms.")
+	pflag.Int64(maxListItemsFlag, viper.GetInt64(maxListItemsFlag), fmt.Sprintf("Maximum Capacity a List may be set to. Supplied by the Agones controller in a cluster. Defaults to %d", defaultMaxListItems))
 	runtime.FeaturesBindFlags()
 	pflag.Parse()
 
@@ -341,7 +351,8 @@ func parseEnvFlags() config {
 	runtime.Must(viper.BindEnv(healthPortFlag))
 	runtime.Must(viper.BindPFlags(pflag.CommandLine))
 	runtime.Must(viper.BindEnv(logLevelFlag))
-	runtime.Must(viper.BindEnv(requestRateLimitFlag))
+	runtime.Must(viper.BindEnv(requestsRateLimitFlag))
+	runtime.Must(viper.BindEnv(maxListItemsFlag))
 	runtime.Must(runtime.FeaturesBindEnv())
 	runtime.Must(runtime.ParseFeaturesFromEnv())
 
@@ -361,7 +372,8 @@ func parseEnvFlags() config {
 		HTTPPort:            viper.GetInt(httpPortFlag),
 		HealthPort:          viper.GetInt(healthPortFlag),
 		LogLevel:            viper.GetString(logLevelFlag),
-		RequestsRateLimit:   viper.GetDuration(requestRateLimitFlag),
+		RequestsRateLimit:   viper.GetDuration(requestsRateLimitFlag),
+		MaxListItems:        viper.GetInt64(maxListItemsFlag),
 	}
 }
 
@@ -383,6 +395,7 @@ type config struct {
 	HealthPort          int
 	LogLevel            string
 	RequestsRateLimit   time.Duration
+	MaxListItems        int64
 }
 
 // healthCheckWrapper ensures that an http 400 response is returned

--- a/install/helm/agones/templates/controller.yaml
+++ b/install/helm/agones/templates/controller.yaml
@@ -141,6 +141,8 @@ spec:
           value: {{ .Values.agones.image.sdk.securityContext | toJson | quote }}
         - name: SIDECAR_REQUESTS_RATE_LIMIT
           value: {{ .Values.agones.sdkServer.requestsRateLimit | quote }}
+        - name: MAX_LIST_ITEMS
+          value: {{ .Values.gameservers.lists.maxItems | quote }}
         - name: SDK_SERVICE_ACCOUNT
           value: {{ .Values.agones.serviceaccount.sdk.name | quote }}
         - name: PROMETHEUS_EXPORTER

--- a/install/helm/agones/templates/extensions-deployment.yaml
+++ b/install/helm/agones/templates/extensions-deployment.yaml
@@ -133,6 +133,8 @@ spec:
           value: {{ .Values.agones.featureGates | quote }}
         - name: ALLOCATION_BATCH_WAIT_TIME
           value: {{ .Values.agones.extensions.allocationBatchWaitTime | quote }}
+        - name: MAX_LIST_ITEMS
+          value: {{ .Values.gameservers.lists.maxItems | quote }}
         - name: CLOUD_PRODUCT
           value: {{ .Values.agones.cloudProduct | quote }}
 {{- if .Values.agones.extensions.persistentLogs }}

--- a/install/helm/agones/templates/processor.yaml
+++ b/install/helm/agones/templates/processor.yaml
@@ -146,6 +146,8 @@ spec:
           value: {{ .Values.agones.allocator.totalRemoteAllocationTimeout | quote }}
         - name: ALLOCATION_BATCH_WAIT_TIME
           value: {{ .Values.agones.allocator.processor.allocationBatchWaitTime | quote }}
+        - name: MAX_LIST_ITEMS
+          value: {{ .Values.gameservers.lists.maxItems | quote }}
         {{- if .Values.agones.allocator.processor.env }}
          {{- toYaml .Values.agones.allocator.processor.env | nindent 8 }}
         {{- end }}

--- a/install/helm/agones/templates/service/allocation.yaml
+++ b/install/helm/agones/templates/service/allocation.yaml
@@ -305,6 +305,8 @@ spec:
           value: {{ .Values.agones.featureGates | quote }}
         - name: ALLOCATION_BATCH_WAIT_TIME
           value: {{ .Values.agones.allocator.allocationBatchWaitTime | quote }}
+        - name: MAX_LIST_ITEMS
+          value: {{ .Values.gameservers.lists.maxItems | quote }}
         - name: READINESS_SHUTDOWN_DURATION
           value: {{ mul .Values.agones.allocator.readiness.periodSeconds .Values.agones.extensions.readiness.failureThreshold 2 }}s
 {{- $featureGates := include "agones.featureGates" . | fromYaml }}

--- a/install/helm/agones/values.schema.json
+++ b/install/helm/agones/values.schema.json
@@ -1573,7 +1573,8 @@
           "type": "object",
           "properties": {
             "maxItems": {
-              "type": "integer"
+              "type": "integer",
+              "minimum": 1
             }
           },
           "required": [

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -20791,6 +20791,8 @@ spec:
           value: "{\"allowPrivilegeEscalation\":false,\"capabilities\":{\"drop\":[\"ALL\"]},\"runAsNonRoot\":true,\"runAsUser\":1000,\"seccompProfile\":{\"type\":\"RuntimeDefault\"}}"
         - name: SIDECAR_REQUESTS_RATE_LIMIT
           value: "500ms"
+        - name: MAX_LIST_ITEMS
+          value: "1000"
         - name: SDK_SERVICE_ACCOUNT
           value: "agones-sdk"
         - name: PROMETHEUS_EXPORTER
@@ -20967,6 +20969,8 @@ spec:
           value: ""
         - name: ALLOCATION_BATCH_WAIT_TIME
           value: "500ms"
+        - name: MAX_LIST_ITEMS
+          value: "1000"
         - name: CLOUD_PRODUCT
           value: "auto"
         - name: LOG_DIR
@@ -21227,6 +21231,8 @@ spec:
           value: ""
         - name: ALLOCATION_BATCH_WAIT_TIME
           value: "500ms"
+        - name: MAX_LIST_ITEMS
+          value: "1000"
         - name: READINESS_SHUTDOWN_DURATION
           value: 18s
         ports:

--- a/pkg/apis/agones/v1/gameserver.go
+++ b/pkg/apis/agones/v1/gameserver.go
@@ -38,11 +38,6 @@ import (
 type GameServerState string
 
 const (
-	// ListMaxCapacity is the maximum capacity for List in the gamerserver spec and status CRDs.
-	ListMaxCapacity = int64(1000)
-)
-
-const (
 	// GameServerStatePortAllocation is for when a dynamically allocating GameServer
 	// is being created, an open port needs to be allocated
 	GameServerStatePortAllocation GameServerState = "PortAllocation"
@@ -240,7 +235,8 @@ type GameServerSpec struct {
 	// Keys must be declared at GameServer creation time.
 	// +optional
 	Counters map[string]CounterStatus `json:"counters,omitempty"`
-	// (Beta, CountsAndLists feature flag) Lists provides the configuration for tracking of lists of up to 1000 values against a GameServer.
+	// (Beta, CountsAndLists feature flag) Lists provides the configuration for tracking of lists of values against a GameServer,
+	// up to the maximum configured by the `gameservers.lists.maxItems` Helm value.
 	// Keys must be declared at GameServer creation time.
 	// +optional
 	Lists map[string]ListStatus `json:"lists,omitempty"`
@@ -1045,11 +1041,12 @@ func (gs *GameServer) UpdateCounterCapacity(name string, capacity int64) error {
 	return gameserverErrors.Errorf("unable to UpdateCounterCapacity: Name %s, Capacity %d. Counter not found in GameServer %s", name, capacity, gs.ObjectMeta.GetName())
 }
 
-// UpdateListCapacity updates the ListStatus Capacity to the given capacity.
-func (gs *GameServer) UpdateListCapacity(name string, capacity int64) error {
+// UpdateListCapacity updates the ListStatus Capacity to the given capacity. The capacity must be
+// within [0, maxCapacity], where maxCapacity comes from the `gameservers.lists.maxItems` Helm value.
+func (gs *GameServer) UpdateListCapacity(name string, capacity, maxCapacity int64) error {
 
-	if capacity < 0 || capacity > ListMaxCapacity {
-		return gameserverErrors.Errorf("unable to UpdateListCapacity: Name %s, Capacity %d. Capacity must be between 0 and 1000, inclusive", name, capacity)
+	if capacity < 0 || capacity > maxCapacity {
+		return gameserverErrors.Errorf("unable to UpdateListCapacity: Name %s, Capacity %d. Capacity must be between 0 and %d, inclusive", name, capacity, maxCapacity)
 	}
 	if list, ok := gs.Status.Lists[name]; ok {
 		list.Capacity = capacity

--- a/pkg/apis/agones/v1/gameserver_test.go
+++ b/pkg/apis/agones/v1/gameserver_test.go
@@ -2272,11 +2272,12 @@ func TestGameServerUpdateListCapacity(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]struct {
-		gs       GameServer
-		name     string
-		capacity int64
-		want     ListStatus
-		wantErr  bool
+		gs          GameServer
+		name        string
+		capacity    int64
+		maxCapacity int64
+		want        ListStatus
+		wantErr     bool
 	}{
 		"list not in game server no-op with error": {
 			gs: GameServer{Status: GameServerStatus{
@@ -2287,9 +2288,10 @@ func TestGameServerUpdateListCapacity(t *testing.T) {
 					},
 				},
 			}},
-			name:     "thing",
-			capacity: 1000,
-			wantErr:  true,
+			name:        "thing",
+			capacity:    1000,
+			maxCapacity: 1000,
+			wantErr:     true,
 		},
 		"update list capacity": {
 			gs: GameServer{Status: GameServerStatus{
@@ -2300,8 +2302,9 @@ func TestGameServerUpdateListCapacity(t *testing.T) {
 					},
 				},
 			}},
-			name:     "things",
-			capacity: 1000,
+			name:        "things",
+			capacity:    1000,
+			maxCapacity: 1000,
 			want: ListStatus{
 				Values:   []string{},
 				Capacity: 1000,
@@ -2317,8 +2320,9 @@ func TestGameServerUpdateListCapacity(t *testing.T) {
 					},
 				},
 			}},
-			name:     "slings",
-			capacity: 10000,
+			name:        "slings",
+			capacity:    10000,
+			maxCapacity: 1000,
 			want: ListStatus{
 				Values:   []string{},
 				Capacity: 100,
@@ -2334,11 +2338,48 @@ func TestGameServerUpdateListCapacity(t *testing.T) {
 					},
 				},
 			}},
-			name:     "flings",
-			capacity: -100,
+			name:        "flings",
+			capacity:    -100,
+			maxCapacity: 1000,
 			want: ListStatus{
 				Values:   []string{},
 				Capacity: 999,
+			},
+			wantErr: true,
+		},
+		"capacity within a configured max below the old hardcoded 1000": {
+			gs: GameServer{Status: GameServerStatus{
+				Lists: map[string]ListStatus{
+					"things": {
+						Values:   []string{},
+						Capacity: 5,
+					},
+				},
+			}},
+			name:        "things",
+			capacity:    25,
+			maxCapacity: 25,
+			want: ListStatus{
+				Values:   []string{},
+				Capacity: 25,
+			},
+			wantErr: false,
+		},
+		"capacity above a configured max below the old hardcoded 1000 no-op with error": {
+			gs: GameServer{Status: GameServerStatus{
+				Lists: map[string]ListStatus{
+					"things": {
+						Values:   []string{},
+						Capacity: 5,
+					},
+				},
+			}},
+			name:        "things",
+			capacity:    26,
+			maxCapacity: 25,
+			want: ListStatus{
+				Values:   []string{},
+				Capacity: 5,
 			},
 			wantErr: true,
 		},
@@ -2346,7 +2387,7 @@ func TestGameServerUpdateListCapacity(t *testing.T) {
 
 	for test, testCase := range testCases {
 		t.Run(test, func(t *testing.T) {
-			err := testCase.gs.UpdateListCapacity(testCase.name, testCase.capacity)
+			err := testCase.gs.UpdateListCapacity(testCase.name, testCase.capacity, testCase.maxCapacity)
 			if err != nil {
 				assert.True(t, testCase.wantErr)
 			} else {

--- a/pkg/apis/allocation/v1/gameserverallocation.go
+++ b/pkg/apis/allocation/v1/gameserverallocation.go
@@ -288,7 +288,7 @@ func (s *GameServerSelector) matchCounters(gs *agonesv1.GameServer) bool {
 	return true
 }
 
-// CounterActions attempts to peform any actions from the CounterAction on the GameServer Counter.
+// CounterActions attempts to perform any actions from the CounterAction on the GameServer Counter.
 // Returns the errors of any actions that could not be performed.
 func (ca *CounterAction) CounterActions(counter string, gs *agonesv1.GameServer) error {
 	var errs error
@@ -307,12 +307,13 @@ func (ca *CounterAction) CounterActions(counter string, gs *agonesv1.GameServer)
 	return errs
 }
 
-// ListActions attempts to peform any actions from the ListAction on the GameServer List.
+// ListActions attempts to perform any actions from the ListAction on the GameServer List.
+// maxCapacity bounds any capacity change, and comes from the `gameservers.lists.maxItems` Helm value.
 // Returns a string list of any actions that could not be performed.
-func (la *ListAction) ListActions(list string, gs *agonesv1.GameServer) error {
+func (la *ListAction) ListActions(list string, gs *agonesv1.GameServer, maxCapacity int64) error {
 	var errs error
 	if la.Capacity != nil {
-		capErr := gs.UpdateListCapacity(list, *la.Capacity)
+		capErr := gs.UpdateListCapacity(list, *la.Capacity, maxCapacity)
 		if capErr != nil {
 			errs = errors.Join(errs, capErr)
 		}

--- a/pkg/apis/allocation/v1/gameserverallocation.go
+++ b/pkg/apis/allocation/v1/gameserverallocation.go
@@ -309,7 +309,7 @@ func (ca *CounterAction) CounterActions(counter string, gs *agonesv1.GameServer)
 
 // ListActions attempts to perform any actions from the ListAction on the GameServer List.
 // maxCapacity bounds any capacity change, and comes from the `gameservers.lists.maxItems` Helm value.
-// Returns a string list of any actions that could not be performed.
+// Returns an error containing any actions that could not be performed.
 func (la *ListAction) ListActions(list string, gs *agonesv1.GameServer, maxCapacity int64) error {
 	var errs error
 	if la.Capacity != nil {

--- a/pkg/apis/allocation/v1/gameserverallocation_test.go
+++ b/pkg/apis/allocation/v1/gameserverallocation_test.go
@@ -836,6 +836,9 @@ func TestGameServerCounterActions(t *testing.T) {
 	}
 }
 
+// defaultTestListMaxCapacity mirrors the `gameservers.lists.maxItems` Helm default.
+const defaultTestListMaxCapacity = int64(1000)
+
 func TestGameServerListActions(t *testing.T) {
 	t.Parallel()
 
@@ -844,11 +847,14 @@ func TestGameServerListActions(t *testing.T) {
 	require.NoError(t, runtime.ParseFeatures(fmt.Sprintf("%s=true", runtime.FeatureCountsAndLists)))
 
 	testScenarios := map[string]struct {
-		la      ListAction
-		list    string
-		gs      *agonesv1.GameServer
-		want    *agonesv1.GameServer
-		wantErr bool
+		la ListAction
+		// maxCapacity bounds a capacity change; left unset in scenarios that do not exercise the
+		// limit, in which case defaultTestListMaxCapacity is used.
+		maxCapacity int64
+		list        string
+		gs          *agonesv1.GameServer
+		want        *agonesv1.GameServer
+		wantErr     bool
 	}{
 		"update list capacity truncates list": {
 			la: ListAction{
@@ -929,11 +935,35 @@ func TestGameServerListActions(t *testing.T) {
 					}}}},
 			wantErr: false,
 		},
+		"capacity above a configured max below the old hardcoded 1000 errors": {
+			la: ListAction{
+				Capacity: int64Pointer(26),
+			},
+			maxCapacity: 25,
+			list:        "pages",
+			gs: &agonesv1.GameServer{Status: agonesv1.GameServerStatus{
+				Lists: map[string]agonesv1.ListStatus{
+					"pages": {
+						Values:   []string{"page1"},
+						Capacity: 5,
+					}}}},
+			want: &agonesv1.GameServer{Status: agonesv1.GameServerStatus{
+				Lists: map[string]agonesv1.ListStatus{
+					"pages": {
+						Values:   []string{"page1"},
+						Capacity: 5,
+					}}}},
+			wantErr: true,
+		},
 	}
 
 	for test, testScenario := range testScenarios {
 		t.Run(test, func(t *testing.T) {
-			errs := testScenario.la.ListActions(testScenario.list, testScenario.gs)
+			maxCapacity := testScenario.maxCapacity
+			if maxCapacity == 0 {
+				maxCapacity = defaultTestListMaxCapacity
+			}
+			errs := testScenario.la.ListActions(testScenario.list, testScenario.gs, maxCapacity)
 			if errs != nil {
 				assert.True(t, testScenario.wantErr)
 			} else {

--- a/pkg/client/applyconfiguration/agones/v1/gameserverspec.go
+++ b/pkg/client/applyconfiguration/agones/v1/gameserverspec.go
@@ -46,7 +46,8 @@ type GameServerSpecApplyConfiguration struct {
 	// (Beta, CountsAndLists feature flag) Counters provides the configuration for tracking of int64 values against a GameServer.
 	// Keys must be declared at GameServer creation time.
 	Counters map[string]CounterStatusApplyConfiguration `json:"counters,omitempty"`
-	// (Beta, CountsAndLists feature flag) Lists provides the configuration for tracking of lists of up to 1000 values against a GameServer.
+	// (Beta, CountsAndLists feature flag) Lists provides the configuration for tracking of lists of values against a GameServer,
+	// up to the maximum configured by the `gameservers.lists.maxItems` Helm value.
 	// Keys must be declared at GameServer creation time.
 	Lists map[string]ListStatusApplyConfiguration `json:"lists,omitempty"`
 	// Eviction specifies the eviction tolerance of the GameServer. Defaults to "Never".

--- a/pkg/gameserverallocations/allocator.go
+++ b/pkg/gameserverallocations/allocator.go
@@ -114,6 +114,7 @@ type Allocator struct {
 	remoteAllocationTimeout      time.Duration
 	totalRemoteAllocationTimeout time.Duration
 	batchWaitTime                time.Duration
+	listMaxCapacity              int64
 	errs                         *errors.Errors
 }
 
@@ -133,7 +134,8 @@ type response struct {
 
 // NewAllocator creates an instance of Allocator
 func NewAllocator(policyInformer multiclusterinformerv1.GameServerAllocationPolicyInformer, secretInformer informercorev1.SecretInformer, gameServerGetter getterv1.GameServersGetter,
-	kubeClient kubernetes.Interface, allocationCache *AllocationCache, remoteAllocationTimeout time.Duration, totalRemoteAllocationTimeout time.Duration, batchWaitTime time.Duration) *Allocator {
+	kubeClient kubernetes.Interface, allocationCache *AllocationCache, remoteAllocationTimeout time.Duration, totalRemoteAllocationTimeout time.Duration, batchWaitTime time.Duration,
+	listMaxCapacity int64) *Allocator {
 	ah := &Allocator{
 		pendingRequests:              make(chan request, maxBatchQueue),
 		allocationPolicyLister:       policyInformer.Lister(),
@@ -143,6 +145,7 @@ func NewAllocator(policyInformer multiclusterinformerv1.GameServerAllocationPoli
 		gameServerGetter:             gameServerGetter,
 		allocationCache:              allocationCache,
 		batchWaitTime:                batchWaitTime,
+		listMaxCapacity:              listMaxCapacity,
 		remoteAllocationTimeout:      remoteAllocationTimeout,
 		totalRemoteAllocationTimeout: totalRemoteAllocationTimeout,
 		remoteAllocationCallback: func(ctx context.Context, endpoint string, dialOpts grpc.DialOption, request *pb.AllocationRequest) (*pb.AllocationResponse, error) {
@@ -674,7 +677,7 @@ func (c *Allocator) applyAllocationToGameServer(ctx context.Context, mp allocati
 	gs.ObjectMeta.Annotations[LastAllocatedAnnotationKey] = string(ts)
 	gs.Status.State = agonesv1.GameServerStateAllocated
 
-	// perfom any Counter or List actions
+	// perform any Counter or List actions
 	var counterErrors error
 	var listErrors error
 	if runtime.FeatureEnabled(runtime.FeatureCountsAndLists) {
@@ -685,7 +688,7 @@ func (c *Allocator) applyAllocationToGameServer(ctx context.Context, mp allocati
 		}
 		if gsa.Spec.Lists != nil {
 			for list, la := range gsa.Spec.Lists {
-				listErrors = goErrors.Join(listErrors, la.ListActions(list, gs))
+				listErrors = goErrors.Join(listErrors, la.ListActions(list, gs, c.listMaxCapacity))
 			}
 		}
 	}

--- a/pkg/gameserverallocations/allocator_test.go
+++ b/pkg/gameserverallocations/allocator_test.go
@@ -42,6 +42,9 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+// defaultTestListMaxCapacity mirrors the `gameservers.lists.maxItems` Helm default.
+const defaultTestListMaxCapacity = int64(1000)
+
 func TestAllocatorAllocate(t *testing.T) {
 	t.Parallel()
 
@@ -254,6 +257,7 @@ func TestAllocatorApplyAllocationToGameServer(t *testing.T) {
 		m.AgonesClient.AgonesV1(), m.KubeClient,
 		NewAllocationCache(m.AgonesInformerFactory.Agones().V1().GameServers(), gameservers.NewPerNodeCounter(m.KubeInformerFactory, m.AgonesInformerFactory), healthcheck.NewHandler()),
 		time.Second, 5*time.Second, 500*time.Millisecond,
+		defaultTestListMaxCapacity,
 	)
 
 	gs, err := allocator.applyAllocationToGameServer(ctx, allocationv1.MetaPatch{}, &agonesv1.GameServer{}, &allocationv1.GameServerAllocation{})
@@ -297,6 +301,7 @@ func TestAllocatorApplyAllocationToGameServerCountsListsActions(t *testing.T) {
 		m.AgonesClient.AgonesV1(), m.KubeClient,
 		NewAllocationCache(m.AgonesInformerFactory.Agones().V1().GameServers(), gameservers.NewPerNodeCounter(m.KubeInformerFactory, m.AgonesInformerFactory), healthcheck.NewHandler()),
 		time.Second, 5*time.Second, 500*time.Millisecond,
+		defaultTestListMaxCapacity,
 	)
 
 	ONE := int64(1)
@@ -441,6 +446,7 @@ func TestAllocationApplyAllocationError(t *testing.T) {
 		m.AgonesClient.AgonesV1(), m.KubeClient,
 		NewAllocationCache(m.AgonesInformerFactory.Agones().V1().GameServers(), gameservers.NewPerNodeCounter(m.KubeInformerFactory, m.AgonesInformerFactory), healthcheck.NewHandler()),
 		time.Second, 5*time.Second, 500*time.Millisecond,
+		defaultTestListMaxCapacity,
 	)
 
 	gsa, err := allocator.applyAllocationToGameServer(ctx, allocationv1.MetaPatch{}, &agonesv1.GameServer{}, &allocationv1.GameServerAllocation{})
@@ -1134,7 +1140,8 @@ func newFakeAllocator() (*Allocator, agtesting.Mocks) {
 		NewAllocationCache(m.AgonesInformerFactory.Agones().V1().GameServers(), counter, healthcheck.NewHandler()),
 		time.Second,
 		5*time.Second,
-		500*time.Millisecond)
+		500*time.Millisecond,
+		defaultTestListMaxCapacity)
 	a.recorder = m.FakeRecorder
 
 	return a, m

--- a/pkg/gameserverallocations/controller.go
+++ b/pkg/gameserverallocations/controller.go
@@ -75,6 +75,7 @@ func NewExtensions(apiServer *apiserver.APIServer,
 	remoteAllocationTimeout time.Duration,
 	totalAllocationTimeout time.Duration,
 	allocationBatchWaitTime time.Duration,
+	listMaxCapacity int64,
 ) *Extensions {
 	c := &Extensions{
 		api: apiServer,
@@ -88,7 +89,8 @@ func NewExtensions(apiServer *apiserver.APIServer,
 		NewAllocationCache(agonesInformerFactory.Agones().V1().GameServers(), counter, health),
 		remoteAllocationTimeout,
 		totalAllocationTimeout,
-		allocationBatchWaitTime)
+		allocationBatchWaitTime,
+		listMaxCapacity)
 
 	c.baseLogger = runtime.NewLoggerWithType(c)
 	c.errs = errors.FromStruct(c)

--- a/pkg/gameserverallocations/controller_test.go
+++ b/pkg/gameserverallocations/controller_test.go
@@ -863,7 +863,7 @@ func newFakeControllerWithTimeout(remoteAllocationTimeout time.Duration, totalRe
 	m.Mux = http.NewServeMux()
 	counter := gameservers.NewPerNodeCounter(m.KubeInformerFactory, m.AgonesInformerFactory)
 	api := apiserver.NewAPIServer(m.Mux)
-	c := NewExtensions(api, healthcheck.NewHandler(), counter, m.KubeClient, m.KubeInformerFactory, m.AgonesClient, m.AgonesInformerFactory, remoteAllocationTimeout, totalRemoteAllocationTimeout, 500*time.Millisecond)
+	c := NewExtensions(api, healthcheck.NewHandler(), counter, m.KubeClient, m.KubeInformerFactory, m.AgonesClient, m.AgonesInformerFactory, remoteAllocationTimeout, totalRemoteAllocationTimeout, 500*time.Millisecond, defaultTestListMaxCapacity)
 	c.recorder = m.FakeRecorder
 	c.allocator.recorder = m.FakeRecorder
 	return c, m

--- a/pkg/gameservers/controller.go
+++ b/pkg/gameservers/controller.go
@@ -90,6 +90,7 @@ type Controller struct {
 	sidecarMemoryLimit       resource.Quantity
 	sidecarSecurityContext   *corev1.SecurityContext
 	sidecarRequestsRateLimit time.Duration
+	listMaxCapacity          int64
 	sdkServiceAccount        string
 	crdGetter                apiextclientv1.CustomResourceDefinitionInterface
 	podGetter                typedcorev1.PodsGetter
@@ -124,6 +125,7 @@ func NewController(
 	sidecarMemoryLimit resource.Quantity,
 	sidecarSecurityContext *corev1.SecurityContext,
 	sidecarRequestsRateLimit time.Duration,
+	listMaxCapacity int64,
 	sdkServiceAccount string,
 	kubeClient kubernetes.Interface,
 	kubeInformerFactory informers.SharedInformerFactory,
@@ -149,6 +151,7 @@ func NewController(
 		sidecarMemoryRequest:     sidecarMemoryRequest,
 		sidecarSecurityContext:   sidecarSecurityContext,
 		sidecarRequestsRateLimit: sidecarRequestsRateLimit,
+		listMaxCapacity:          listMaxCapacity,
 		alwaysPullSidecarImage:   alwaysPullSidecarImage,
 		sdkServiceAccount:        sdkServiceAccount,
 		crdGetter:                extClient.ApiextensionsV1().CustomResourceDefinitions(),
@@ -771,6 +774,10 @@ func (c *Controller) sidecar(gs *agonesv1.GameServer) corev1.Container {
 			{
 				Name:  "REQUESTS_RATE_LIMIT",
 				Value: c.sidecarRequestsRateLimit.String(),
+			},
+			{
+				Name:  "MAX_LIST_ITEMS",
+				Value: strconv.FormatInt(c.listMaxCapacity, 10),
 			},
 		},
 		Resources: corev1.ResourceRequirements{},

--- a/pkg/gameservers/controller_test.go
+++ b/pkg/gameservers/controller_test.go
@@ -1610,7 +1610,7 @@ func TestControllerCreateGameServerPod(t *testing.T) {
 			assert.Equal(t, sidecarContainer.Resources.Requests.Cpu(), &c.sidecarCPURequest)
 			assert.Equal(t, sidecarContainer.Resources.Limits.Memory(), &c.sidecarMemoryLimit)
 			assert.Equal(t, sidecarContainer.Resources.Requests.Memory(), &c.sidecarMemoryRequest)
-			assert.Len(t, sidecarContainer.Env, 5, "5 env vars")
+			assert.Len(t, sidecarContainer.Env, 6, "6 env vars")
 			assert.Equal(t, "GAMESERVER_NAME", sidecarContainer.Env[0].Name)
 			assert.Equal(t, fixture.ObjectMeta.Name, sidecarContainer.Env[0].Value)
 			assert.Equal(t, "POD_NAMESPACE", sidecarContainer.Env[1].Name)
@@ -1618,6 +1618,8 @@ func TestControllerCreateGameServerPod(t *testing.T) {
 			assert.Equal(t, "LOG_LEVEL", sidecarContainer.Env[3].Name)
 			assert.Equal(t, "REQUESTS_RATE_LIMIT", sidecarContainer.Env[4].Name)
 			assert.Equal(t, "500ms", sidecarContainer.Env[4].Value)
+			assert.Equal(t, "MAX_LIST_ITEMS", sidecarContainer.Env[5].Name)
+			assert.Equal(t, "1000", sidecarContainer.Env[5].Value)
 			assert.Equal(t, string(fixture.Spec.SdkServer.LogLevel), sidecarContainer.Env[3].Value)
 			assert.False(t, *sidecarContainer.SecurityContext.AllowPrivilegeEscalation)
 			assert.True(t, *sidecarContainer.SecurityContext.RunAsNonRoot)
@@ -2595,6 +2597,10 @@ func TestControllerSidecarSecurityContext(t *testing.T) {
 }
 
 // newFakeController returns a controller, backed by the fake Clientset
+// defaultTestListMaxCapacity mirrors the `gameservers.lists.maxItems` Helm default, which the
+// controller passes to the sidecar via MAX_LIST_ITEMS.
+const defaultTestListMaxCapacity = int64(1000)
+
 func newFakeController() (*Controller, agtesting.Mocks) {
 	m := agtesting.NewMocks()
 	c := NewController(
@@ -2603,7 +2609,8 @@ func newFakeController() (*Controller, agtesting.Mocks) {
 		map[string]portallocator.PortRange{agonesv1.DefaultPortRange: {MinPort: 10, MaxPort: 20}},
 		"sidecar:dev", false,
 		resource.MustParse("0.05"), resource.MustParse("0.1"),
-		resource.MustParse("50Mi"), resource.MustParse("100Mi"), DefaultSidecarSecurityContext(sidecarRunAsUser), 500*time.Millisecond, "sdk-service-account",
+		resource.MustParse("50Mi"), resource.MustParse("100Mi"), DefaultSidecarSecurityContext(sidecarRunAsUser), 500*time.Millisecond,
+		defaultTestListMaxCapacity, "sdk-service-account",
 		m.KubeClient, m.KubeInformerFactory, m.ExtClient, m.AgonesClient, m.AgonesInformerFactory)
 	c.recorder = m.FakeRecorder
 	return c, m

--- a/pkg/sdkserver/localsdk.go
+++ b/pkg/sdkserver/localsdk.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"math/rand"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -44,6 +45,9 @@ var (
 	_ alpha.SDKServer = &LocalSDKServer{}
 	_ beta.SDKServer  = &LocalSDKServer{}
 )
+
+// defaultNamespace is the namespace given to the GameServer the local SDK server serves.
+const defaultNamespace = "default"
 
 func defaultGs() *sdk.GameServer {
 	gs := &sdk.GameServer{
@@ -103,10 +107,12 @@ type LocalSDKServer struct {
 	reserveTimer      *time.Timer
 	testMode          bool
 	testSdkName       string
+	listMaxCapacity   int64
 }
 
-// NewLocalSDKServer returns the default LocalSDKServer
-func NewLocalSDKServer(filePath string, testSdkName string) (*LocalSDKServer, error) {
+// NewLocalSDKServer returns the default LocalSDKServer. listMaxCapacity bounds the Capacity
+// accepted by UpdateList.
+func NewLocalSDKServer(filePath string, testSdkName string, listMaxCapacity int64) (*LocalSDKServer, error) {
 	l := &LocalSDKServer{
 		gsMutex:         sync.RWMutex{},
 		gs:              defaultGs(),
@@ -117,6 +123,7 @@ func NewLocalSDKServer(filePath string, testSdkName string) (*LocalSDKServer, er
 		testMode:        false,
 		testSdkName:     testSdkName,
 		gsState:         agonesv1.GameServerStateScheduled,
+		listMaxCapacity: listMaxCapacity,
 	}
 	l.logger = runtime.NewLoggerWithType(l)
 
@@ -741,15 +748,8 @@ func (l *LocalSDKServer) UpdateList(_ context.Context, in *beta.UpdateListReques
 		return nil, errors.Errorf("invalid argument. Field Mask Path(s): %v are invalid for List. Use valid field name(s): %v", in.UpdateMask.GetPaths(), in.List.ProtoReflect().Descriptor().Fields())
 	}
 
-	if GameServerListMaxCapacity == 0 {
-		err := l.GsLocalListsMaxItems()
-		if err != nil {
-			return nil, fmt.Errorf("%w", err)
-		}
-	}
-
-	if in.List.Capacity < 0 || in.List.Capacity > GameServerListMaxCapacity {
-		return nil, errors.Errorf("out of range. Capacity must be within range [0,1000]. Found Capacity: %d", in.List.Capacity)
+	if in.List.Capacity < 0 || in.List.Capacity > l.listMaxCapacity {
+		return nil, errors.Errorf("out of range. Capacity must be within range [0,%d]. Found Capacity: %d", l.listMaxCapacity, in.List.Capacity)
 	}
 
 	name := in.List.Name
@@ -796,10 +796,8 @@ func (l *LocalSDKServer) AddListValue(_ context.Context, in *beta.AddListValueRe
 			return nil, errors.Errorf("out of range. No available capacity. Current Capacity: %d, List Size: %d", list.Capacity, len(list.Values))
 		}
 		// Verify value does not already exist in the list
-		for _, val := range l.gs.Status.Lists[in.Name].Values {
-			if in.Value == val {
-				return nil, errors.Errorf("already exists. Value: %s already in List: %s", in.Value, in.Name)
-			}
+		if slices.Contains(l.gs.Status.Lists[in.Name].Values, in.Value) {
+			return nil, errors.Errorf("already exists. Value: %s already in List: %s", in.Value, in.Name)
 		}
 		// Add new value to gameserverstatus.
 		l.gs.Status.Lists[in.Name].Values = append(l.gs.Status.Lists[in.Name].Values, in.Value)
@@ -925,18 +923,5 @@ func (l *LocalSDKServer) setGameServerFromFilePath(filePath string) error {
 		l.logger.WithError(err).Warn("Specified wrong Logging.SdkServer. Setting default loglevel - Info")
 		l.logger.Logger.SetLevel(logrus.InfoLevel)
 	}
-	return nil
-}
-
-// GsLocalListsMaxItems retrieves or sets the maximum number of items allowed
-// in any GameServer list for the local SDK.
-func (l *LocalSDKServer) GsLocalListsMaxItems() error {
-
-	if playersList, found := l.gs.Status.Lists["players"]; found {
-		GameServerListMaxCapacity = playersList.Capacity
-	} else {
-		return fmt.Errorf("no players for list")
-	}
-
 	return nil
 }

--- a/pkg/sdkserver/localsdk_test.go
+++ b/pkg/sdkserver/localsdk_test.go
@@ -42,7 +42,7 @@ import (
 func TestLocal(t *testing.T) {
 	ctx := context.Background()
 	e := &sdk.Empty{}
-	l, err := NewLocalSDKServer("", "")
+	l, err := NewLocalSDKServer("", "", defaultTestListMaxCapacity)
 	assert.NoError(t, err)
 
 	_, err = l.Ready(ctx, e)
@@ -82,7 +82,7 @@ func TestLocal(t *testing.T) {
 }
 
 func TestLocalSDKWithTestMode(t *testing.T) {
-	l, err := NewLocalSDKServer("", "")
+	l, err := NewLocalSDKServer("", "", defaultTestListMaxCapacity)
 	assert.NoError(t, err, "Should be able to create local SDK server")
 	a := []string{"ready", "allocate", "setlabel", "setannotation", "gameserver", "health", "shutdown", "watch"}
 	b := []string{"ready", "health", "ready", "watch", "allocate", "gameserver", "setlabel", "setannotation", "health", "health", "shutdown"}
@@ -107,7 +107,7 @@ func TestLocalSDKWithGameServer(t *testing.T) {
 	path, err := gsToTmpFile(fixture.DeepCopy())
 	assert.NoError(t, err)
 
-	l, err := NewLocalSDKServer(path, "")
+	l, err := NewLocalSDKServer(path, "", defaultTestListMaxCapacity)
 	assert.NoError(t, err)
 
 	gs, err := l.GetGameServer(ctx, e)
@@ -130,7 +130,7 @@ func TestLocalSDKWithLogLevel(t *testing.T) {
 	path, err := gsToTmpFile(fixture.DeepCopy())
 	assert.NoError(t, err)
 
-	l, err := NewLocalSDKServer(path, "test")
+	l, err := NewLocalSDKServer(path, "test", defaultTestListMaxCapacity)
 	assert.NoError(t, err)
 
 	_, err = l.GetGameServer(ctx, e)
@@ -165,7 +165,7 @@ func TestLocalSDKServerSetLabel(t *testing.T) {
 			path, err := gsToTmpFile(v.gs)
 			assert.NoError(t, err)
 
-			l, err := NewLocalSDKServer(path, "")
+			l, err := NewLocalSDKServer(path, "", defaultTestListMaxCapacity)
 			assert.NoError(t, err)
 			kv := &sdk.KeyValue{Key: "foo", Value: "bar"}
 
@@ -233,7 +233,7 @@ func TestLocalSDKServerSetAnnotation(t *testing.T) {
 			path, err := gsToTmpFile(v.gs)
 			assert.NoError(t, err)
 
-			l, err := NewLocalSDKServer(path, "")
+			l, err := NewLocalSDKServer(path, "", defaultTestListMaxCapacity)
 			assert.NoError(t, err)
 
 			kv := &sdk.KeyValue{Key: "bar", Value: "foo"}
@@ -285,7 +285,7 @@ func TestLocalSDKServerWatchGameServer(t *testing.T) {
 	assert.NoError(t, err)
 
 	e := &sdk.Empty{}
-	l, err := NewLocalSDKServer(path, "")
+	l, err := NewLocalSDKServer(path, "", defaultTestListMaxCapacity)
 	assert.NoError(t, err)
 
 	stream := newGameServerMockStream()
@@ -338,7 +338,7 @@ func TestLocalSDKServerGetCounter(t *testing.T) {
 
 	path, err := gsToTmpFile(fixture)
 	assert.NoError(t, err)
-	l, err := NewLocalSDKServer(path, "")
+	l, err := NewLocalSDKServer(path, "", defaultTestListMaxCapacity)
 	assert.NoError(t, err)
 
 	stream := newGameServerMockStream()
@@ -414,7 +414,7 @@ func TestLocalSDKServerUpdateCounter(t *testing.T) {
 
 	path, err := gsToTmpFile(fixture)
 	assert.NoError(t, err)
-	l, err := NewLocalSDKServer(path, "")
+	l, err := NewLocalSDKServer(path, "", defaultTestListMaxCapacity)
 	assert.NoError(t, err)
 
 	stream := newGameServerMockStream()
@@ -562,7 +562,7 @@ func TestLocalSDKServerGetList(t *testing.T) {
 
 	path, err := gsToTmpFile(fixture)
 	assert.NoError(t, err)
-	l, err := NewLocalSDKServer(path, "")
+	l, err := NewLocalSDKServer(path, "", defaultTestListMaxCapacity)
 	assert.NoError(t, err)
 
 	stream := newGameServerMockStream()
@@ -639,7 +639,7 @@ func TestLocalSDKServerUpdateList(t *testing.T) {
 
 	path, err := gsToTmpFile(fixture)
 	assert.NoError(t, err)
-	l, err := NewLocalSDKServer(path, "")
+	l, err := NewLocalSDKServer(path, "", defaultTestListMaxCapacity)
 	assert.NoError(t, err)
 
 	stream := newGameServerMockStream()
@@ -835,7 +835,7 @@ func TestLocalSDKServerAddListValue(t *testing.T) {
 
 	path, err := gsToTmpFile(fixture)
 	assert.NoError(t, err)
-	l, err := NewLocalSDKServer(path, "")
+	l, err := NewLocalSDKServer(path, "", defaultTestListMaxCapacity)
 	assert.NoError(t, err)
 
 	stream := newGameServerMockStream()
@@ -927,7 +927,7 @@ func TestLocalSDKServerRemoveListValue(t *testing.T) {
 
 	path, err := gsToTmpFile(fixture)
 	assert.NoError(t, err)
-	l, err := NewLocalSDKServer(path, "")
+	l, err := NewLocalSDKServer(path, "", defaultTestListMaxCapacity)
 	assert.NoError(t, err)
 
 	stream := newGameServerMockStream()
@@ -996,7 +996,7 @@ func TestLocalSDKServerRemoveListValue(t *testing.T) {
 // GameServer object
 func TestLocalSDKServerStateUpdates(t *testing.T) {
 	t.Parallel()
-	l, err := NewLocalSDKServer("", "")
+	l, err := NewLocalSDKServer("", "", defaultTestListMaxCapacity)
 	assert.NoError(t, err)
 
 	ctx := context.Background()
@@ -1035,7 +1035,7 @@ func TestLocalSDKServerStateUpdates(t *testing.T) {
 func TestSDKConformanceFunctionality(t *testing.T) {
 	t.Parallel()
 
-	l, err := NewLocalSDKServer("", "")
+	l, err := NewLocalSDKServer("", "", defaultTestListMaxCapacity)
 	assert.NoError(t, err)
 	l.testMode = true
 	l.recordRequest("")
@@ -1102,5 +1102,58 @@ func assertInitialWatchUpdate(t *testing.T, stream *gameServerMockStream) {
 	case <-stream.msgs:
 	case <-time.After(time.Second):
 		assert.Fail(t, "timeout on receiving initial message")
+	}
+}
+
+// TestLocalSDKServerUpdateListMaxCapacity verifies the local SDK server range-checks UpdateList
+// against the limit it was constructed with. Locally that comes from the --max-list-items flag,
+// which defaults to defaultMaxListItems rather than being discovered from the GameServer.
+func TestLocalSDKServerUpdateListMaxCapacity(t *testing.T) {
+	t.Parallel()
+
+	runtime.FeatureTestMutex.Lock()
+	defer runtime.FeatureTestMutex.Unlock()
+	require.NoError(t, runtime.ParseFeatures(string(runtime.FeatureCountsAndLists)+"=true"))
+
+	const listMaxCapacity = int64(25)
+
+	fixture := &agonesv1.GameServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "stuff"},
+		Status: agonesv1.GameServerStatus{
+			// Deliberately not named "players": the removed GsLocalListsMaxItems only ever
+			// discovered a limit from a list with that name.
+			Lists: map[string]agonesv1.ListStatus{"rooms": {Capacity: 5, Values: []string{"one"}}},
+		},
+	}
+
+	path, err := gsToTmpFile(fixture)
+	require.NoError(t, err)
+	l, err := NewLocalSDKServer(path, "", listMaxCapacity)
+	require.NoError(t, err)
+
+	testScenarios := map[string]struct {
+		capacity int64
+		wantErr  bool
+	}{
+		"at the configured maximum":    {capacity: listMaxCapacity, wantErr: false},
+		"above the configured maximum": {capacity: listMaxCapacity + 1, wantErr: true},
+		// Would have been accepted under the old hardcoded [0,1000] check.
+		"between the configured maximum and the old hardcoded 1000": {capacity: 500, wantErr: true},
+		"negative": {capacity: -1, wantErr: true},
+	}
+
+	for test, testScenario := range testScenarios {
+		t.Run(test, func(t *testing.T) {
+			_, err := l.UpdateList(context.Background(), &beta.UpdateListRequest{
+				List:       &beta.List{Name: "rooms", Capacity: testScenario.capacity},
+				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"capacity"}},
+			})
+			if testScenario.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "Capacity must be within range [0,25]")
+			} else {
+				require.NoError(t, err)
+			}
+		})
 	}
 }

--- a/pkg/sdkserver/sdkserver.go
+++ b/pkg/sdkserver/sdkserver.go
@@ -36,7 +36,6 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -64,11 +63,6 @@ import (
 // Operation is a synchronisation action
 type Operation string
 
-var (
-	// GameServerListMaxCapacity is the maximum capacity for List in the gamerserver spec and status CRDs.
-	GameServerListMaxCapacity int64
-)
-
 const (
 	updateState            Operation     = "updateState"
 	updateLabel            Operation     = "updateLabel"
@@ -79,9 +73,6 @@ const (
 	updateLists            Operation     = "updateLists"
 	updatePeriod           time.Duration = time.Second
 )
-
-// defaultNamespace is the Kubernetes namespace assumed when none is configured.
-const defaultNamespace = "default"
 
 // readHeaderTimeout bounds how long a client may take to send its request
 // headers, so a Slowloris client cannot hold the listener open indefinitely.
@@ -152,12 +143,14 @@ type SDKServer struct {
 	gsCounterUpdates    map[string]counterUpdateRequest
 	gsListUpdates       map[string]listUpdateRequest
 	gsCopy              *agonesv1.GameServer
+	listMaxCapacity     int64
 }
 
 // NewSDKServer creates a SDKServer that sets up an
 // InClusterConfig for Kubernetes
 func NewSDKServer(gameServerName, namespace string, kubeClient kubernetes.Interface,
-	agonesClient versioned.Interface, logLevel logrus.Level, healthPort int, requestsRateLimit time.Duration) (*SDKServer, error) {
+	agonesClient versioned.Interface, logLevel logrus.Level, healthPort int, requestsRateLimit time.Duration,
+	listMaxCapacity int64) (*SDKServer, error) {
 	mux := http.NewServeMux()
 	resync := 0 * time.Second
 
@@ -190,6 +183,7 @@ func NewSDKServer(gameServerName, namespace string, kubeClient kubernetes.Interf
 		gsWaitForSync:      sync.WaitGroup{},
 		gsConnectedPlayers: []string{},
 		gsStateChannel:     make(chan agonesv1.GameServerState, 2),
+		listMaxCapacity:    listMaxCapacity,
 	}
 
 	if runtime.FeatureEnabled(runtime.FeatureCountsAndLists) {
@@ -1139,7 +1133,7 @@ func (s *SDKServer) GetList(_ context.Context, in *beta.GetListRequest) (*beta.L
 // UpdateList collapses all update capacity requests for a given List into a single UpdateList request.
 // This function currently only updates the Capacity of a List.
 // Returns error if the List does not exist (name cannot be updated).
-// Returns error if the List update capacity is out of range [0,1000].
+// Returns error if the List update capacity is out of range [0,listMaxCapacity].
 // [Stage:Beta]
 // [FeatureFlag:CountsAndLists]
 func (s *SDKServer) UpdateList(ctx context.Context, in *beta.UpdateListRequest) (*beta.List, error) {
@@ -1156,14 +1150,8 @@ func (s *SDKServer) UpdateList(ctx context.Context, in *beta.UpdateListRequest) 
 		return nil, errors.Errorf("invalid argument. Field Mask Path(s): %v are invalid for List. Use valid field name(s): %v", in.UpdateMask.GetPaths(), in.List.ProtoReflect().Descriptor().Fields())
 	}
 
-	if GameServerListMaxCapacity == 0 {
-		err := s.GsListsMaxItems(ctx)
-		if err != nil {
-			return nil, errors.Errorf("%v", err)
-		}
-	}
-	if in.List.Capacity < 0 || in.List.Capacity > GameServerListMaxCapacity {
-		return nil, errors.Errorf("out of range. Capacity must be within range [0,1000]. Found Capacity: %d", in.List.Capacity)
+	if in.List.Capacity < 0 || in.List.Capacity > s.listMaxCapacity {
+		return nil, errors.Errorf("out of range. Capacity must be within range [0,%d]. Found Capacity: %d", s.listMaxCapacity, in.List.Capacity)
 	}
 
 	list, err := s.GetList(ctx, &beta.GetListRequest{Name: in.List.Name})
@@ -1600,63 +1588,4 @@ func (s *SDKServer) gsListUpdatesLen() int {
 	s.gsUpdateMutex.RLock()
 	defer s.gsUpdateMutex.RUnlock()
 	return len(s.gsListUpdates)
-}
-
-// GsListsMaxItems lists all GameServers belonging to a specific fleet and attempts
-// to retrieve the maximum capacity defined for a given listName in the GameServer's Spec.
-// It returns the capacity of the first GameServer found that defines the list.
-func (s *SDKServer) GsListsMaxItems(ctx context.Context) error {
-
-	var labelsName string
-	if s.namespace == defaultNamespace {
-		labelsName = "fleet-example"
-	} else {
-		gs, err := s.gameServerGetter.GameServers(s.namespace).Get(
-			ctx,
-			s.gameServerName,
-			metav1.GetOptions{},
-		)
-		if err != nil {
-			return errors.Wrapf(err, "failed to get GameServer %s", s.gameServerName)
-		}
-		if gs == nil {
-			return errors.Errorf("retrieved nil GameServer %s", s.gameServerName)
-		}
-		labelsName = gs.ObjectMeta.Labels[agonesv1.FleetNameLabel]
-	}
-	selector := labels.Set{
-		agonesv1.FleetNameLabel: labelsName,
-	}
-
-	labelSelector := selector.String()
-	gsList, err := s.gameServerGetter.GameServers(s.namespace).List(
-		ctx,
-		metav1.ListOptions{
-			LabelSelector: labelSelector,
-		},
-	)
-	if err != nil {
-		return fmt.Errorf("failed to list GameServers for fleet %s: %w", "fleet-example", err)
-	}
-
-	if len(gsList.Items) == 0 {
-		return fmt.Errorf("no gameservers for fleet")
-	}
-	for i := range gsList.Items {
-		// Get a pointer to the listed item (only for accessing the name)
-		listedGS := &gsList.Items[i]
-		// Fetch the current GameServer resource
-		gs, err := s.gameServerGetter.GameServers(s.namespace).Get(
-			ctx,
-			listedGS.Name, // Use the name from the listed item
-			metav1.GetOptions{},
-		)
-		if err != nil {
-			return fmt.Errorf("failed to get GameServer %s: %w", listedGS.Name, err)
-		}
-		if playersList, found := gs.Spec.Lists["players"]; found {
-			GameServerListMaxCapacity = playersList.Capacity
-		}
-	}
-	return nil
 }

--- a/pkg/sdkserver/sdkserver_test.go
+++ b/pkg/sdkserver/sdkserver_test.go
@@ -49,6 +49,10 @@ import (
 	testclocks "k8s.io/utils/clock/testing"
 )
 
+// defaultTestListMaxCapacity mirrors the `gameservers.lists.maxItems` Helm default, which is what
+// the controller supplies to the sidecar via MAX_LIST_ITEMS in a real cluster.
+const defaultTestListMaxCapacity = int64(1000)
+
 // patchGameServer is a helper function for the AddReactor "patch" that creates and applies a patch
 // to a gameserver. Returns a patched copy and does not modify the original game server.
 func patchGameServer(t *testing.T, action k8stesting.Action, gs *agonesv1.GameServer) *agonesv1.GameServer {
@@ -207,7 +211,7 @@ func TestSidecarRun(t *testing.T) {
 				return true, gsCopy, nil
 			})
 
-			sc, err := NewSDKServer("test", "default", m.KubeClient, m.AgonesClient, logrus.DebugLevel, 8080, 500*time.Millisecond)
+			sc, err := NewSDKServer("test", "default", m.KubeClient, m.AgonesClient, logrus.DebugLevel, 8080, 500*time.Millisecond, defaultTestListMaxCapacity)
 			stop := make(chan struct{})
 			defer close(stop)
 			ctx, cancel := context.WithCancel(context.Background())
@@ -464,7 +468,7 @@ func TestSidecarUnhealthyMessage(t *testing.T) {
 	t.Parallel()
 
 	m := agtesting.NewMocks()
-	sc, err := NewSDKServer("test", "default", m.KubeClient, m.AgonesClient, logrus.DebugLevel, 8080, 500*time.Millisecond)
+	sc, err := NewSDKServer("test", "default", m.KubeClient, m.AgonesClient, logrus.DebugLevel, 8080, 500*time.Millisecond, defaultTestListMaxCapacity)
 	require.NoError(t, err)
 
 	gs := agonesv1.GameServer{
@@ -615,7 +619,7 @@ func TestSidecarHealthy(t *testing.T) {
 
 func TestSidecarHTTPHealthCheck(t *testing.T) {
 	m := agtesting.NewMocks()
-	sc, err := NewSDKServer("test", "default", m.KubeClient, m.AgonesClient, logrus.DebugLevel, 8080, 500*time.Millisecond)
+	sc, err := NewSDKServer("test", "default", m.KubeClient, m.AgonesClient, logrus.DebugLevel, 8080, 500*time.Millisecond, defaultTestListMaxCapacity)
 	require.NoError(t, err)
 
 	now := time.Now().Add(time.Hour).UTC()
@@ -1795,9 +1799,6 @@ func TestSDKServerUpdateList(t *testing.T) {
 			expectedUpdatesQueueLen: 0,
 		},
 	}
-	// Maximum capacity for the game server list.
-	// of game server items the system can manage at once.
-	GameServerListMaxCapacity = int64(1000)
 	// nolint:dupl  // Linter errors on lines are duplicate of TestSDKServerAddListValue, TestSDKServerRemoveListValue
 	for test, testCase := range fixtures {
 		t.Run(test, func(t *testing.T) {
@@ -2092,7 +2093,7 @@ func TestSDKServerGracefulTerminationGameServerStateChannel(t *testing.T) {
 }
 
 func defaultSidecar(m agtesting.Mocks) (*SDKServer, error) {
-	server, err := NewSDKServer("test", "default", m.KubeClient, m.AgonesClient, logrus.DebugLevel, 8080, 500*time.Millisecond)
+	server, err := NewSDKServer("test", "default", m.KubeClient, m.AgonesClient, logrus.DebugLevel, 8080, 500*time.Millisecond, defaultTestListMaxCapacity)
 	if err != nil {
 		return server, err
 	}
@@ -2175,6 +2176,86 @@ func TestSetAnnotation_NilAndOverlimit(t *testing.T) {
 			st, ok := status.FromError(err)
 			assert.True(t, ok)
 			assert.Equal(t, codes.InvalidArgument, st.Code())
+		})
+	}
+}
+
+// TestSDKServerUpdateListMaxCapacity verifies that UpdateList range-checks against the limit the
+// SDKServer was constructed with, rather than a hardcoded 1000. In a cluster that limit originates
+// from the `gameservers.lists.maxItems` Helm value, arriving via the MAX_LIST_ITEMS env var.
+func TestSDKServerUpdateListMaxCapacity(t *testing.T) {
+	t.Parallel()
+	agruntime.FeatureTestMutex.Lock()
+	defer agruntime.FeatureTestMutex.Unlock()
+
+	require.NoError(t, agruntime.ParseFeatures(string(agruntime.FeatureCountsAndLists)+"=true"))
+
+	const listMaxCapacity = int64(25)
+
+	fixtures := map[string]struct {
+		capacity int64
+		wantErr  bool
+	}{
+		"at the configured maximum":    {capacity: listMaxCapacity, wantErr: false},
+		"above the configured maximum": {capacity: listMaxCapacity + 1, wantErr: true},
+		// Would have been accepted under the old hardcoded [0,1000] check.
+		"between the configured maximum and the old hardcoded 1000": {capacity: 500, wantErr: true},
+		"negative": {capacity: -1, wantErr: true},
+	}
+
+	for test, testCase := range fixtures {
+		t.Run(test, func(t *testing.T) {
+			m := agtesting.NewMocks()
+
+			gs := agonesv1.GameServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test", Namespace: "default", ResourceVersion: "0", Generation: 1,
+				},
+				Spec: agonesv1.GameServerSpec{
+					SdkServer: agonesv1.SdkServer{LogLevel: "Debug"},
+				},
+				Status: agonesv1.GameServerStatus{
+					Lists: map[string]agonesv1.ListStatus{
+						// Deliberately not named "players": the removed GsListsMaxItems only ever
+						// discovered a limit from a list with that name.
+						"rooms": {Values: []string{"one"}, Capacity: int64(5)},
+					},
+				},
+			}
+			gs.ApplyDefaults()
+
+			m.AgonesClient.AddReactor("list", "gameservers", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+				return true, &agonesv1.GameServerList{Items: []agonesv1.GameServer{*gs.DeepCopy()}}, nil
+			})
+			m.AgonesClient.AddReactor("patch", "gameservers", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				return true, patchGameServer(t, action, &gs), nil
+			})
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			sc, err := NewSDKServer("test", "default", m.KubeClient, m.AgonesClient,
+				logrus.DebugLevel, 8080, 500*time.Millisecond, listMaxCapacity)
+			require.NoError(t, err)
+			sc.recorder = m.FakeRecorder
+
+			require.NoError(t, sc.WaitForConnection(ctx))
+			sc.informerFactory.Start(ctx.Done())
+			require.True(t, cache.WaitForCacheSync(ctx.Done(), sc.gameServerSynced))
+			sc.gsWaitForSync.Done()
+
+			_, err = sc.UpdateList(ctx, &beta.UpdateListRequest{
+				List:       &beta.List{Name: "rooms", Capacity: testCase.capacity},
+				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"capacity"}},
+			})
+
+			if testCase.wantErr {
+				require.Error(t, err)
+				// The limit must be reported accurately, not as the old hardcoded [0,1000].
+				assert.Contains(t, err.Error(), "Capacity must be within range [0,25]")
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
 }

--- a/site/content/en/docs/Installation/Install Agones/helm.md
+++ b/site/content/en/docs/Installation/Install Agones/helm.md
@@ -424,7 +424,7 @@ The following tables lists the configurable parameters of the Agones chart and t
 | `gameservers.additionalPortRanges`     | Port ranges from which to do named dynamic port allocation. Example: <br /> additionalPortRanges: <br />&nbsp;&nbsp;game: [9000, 10000] | `{}`                                   |
 | `gameservers.podPreserveUnknownFields` | Disable [field pruning][pruning] and schema validation on the Pod template for a [GameServer][gameserver] definition                    | `false`                                |
 | `gameservers.selectableFields`         | spec fields available for querying [GameServer][gameserver] resources.                                                                  | `[".status.state", "status.nodeName"]` |
-| `gameservers.lists.maxItems`           | The maximum number of items that can be specified for a list.                                                                           | `1000`                                 |
+| `gameservers.lists.maxItems`           | The maximum number of items that can be specified for a list. Also bounds the Capacity accepted by the SDK's `UpdateList` and by list actions during allocation. | `1000`                                 |
 
 ### Helm Installation
 

--- a/site/content/en/docs/Reference/agones_crd_api_reference.html
+++ b/site/content/en/docs/Reference/agones_crd_api_reference.html
@@ -3,7 +3,7 @@ title="Agones Kubernetes API"
 description="Detailed list of Agones Custom Resource Definitions available"
 +++
 
-{{% feature publishVersion="1.60.0" %}}
+{{% feature expiryVersion="1.61.0" %}}
 <p>Packages:</p>
 <ul>
 <li>
@@ -4969,3 +4969,4973 @@ ClusterConnectionInfo
 Generated with <code>gen-crd-api-reference-docs</code>.
 </em></p>
 {{% /feature %}}
+{{% feature publishVersion="1.61.0" %}}
+<p>Packages:</p>
+<ul>
+<li>
+<a href="#agones.dev%2fv1">agones.dev/v1</a>
+</li>
+<li>
+<a href="#allocation.agones.dev%2fv1">allocation.agones.dev/v1</a>
+</li>
+<li>
+<a href="#autoscaling.agones.dev%2fv1">autoscaling.agones.dev/v1</a>
+</li>
+<li>
+<a href="#multicluster.agones.dev%2fv1">multicluster.agones.dev/v1</a>
+</li>
+</ul>
+<h2 id="agones.dev/v1">agones.dev/v1</h2>
+<p>
+<p>Package v1 is the v1 version of the API.</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#agones.dev/v1.Fleet">Fleet</a>
+</li><li>
+<a href="#agones.dev/v1.GameServer">GameServer</a>
+</li><li>
+<a href="#agones.dev/v1.GameServerSet">GameServerSet</a>
+</li></ul>
+<h3 id="agones.dev/v1.Fleet">Fleet
+</h3>
+<p>
+<p>Fleet is the data structure for a Fleet resource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+string</td>
+<td>
+<code>
+agones.dev/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br/>
+string
+</td>
+<td><code>Fleet</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://v1-35.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#agones.dev/v1.FleetSpec">
+FleetSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>replicas</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>Replicas are the number of GameServers that should be in this set. Defaults to 0.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>allocationOverflow</code><br/>
+<em>
+<a href="#agones.dev/v1.AllocationOverflow">
+AllocationOverflow
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Labels and/or Annotations to apply to overflowing GameServers when the number of Allocated GameServers is more
+than the desired replicas on the underlying <code>GameServerSet</code></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>strategy</code><br/>
+<em>
+<a href="https://v1-35.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#deploymentstrategy-v1-apps">
+Kubernetes apps/v1.DeploymentStrategy
+</a>
+</em>
+</td>
+<td>
+<p>Deployment strategy</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scheduling</code><br/>
+<em>
+agones.dev/agones/pkg/apis.SchedulingStrategy
+</em>
+</td>
+<td>
+<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>priorities</code><br/>
+<em>
+<a href="#agones.dev/v1.Priority">
+[]Priority
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage: Beta]
+[FeatureFlag:CountsAndLists]
+<code>Priorities</code> configuration alters scale down logic in Fleets based on the configured available capacity order under that key.</p>
+<p>Priority of sorting is in descending importance. I.e. The position 0 <code>priority</code> entry is checked first.</p>
+<p>For <code>Packed</code> strategy scale down, this priority list will be the tie-breaker within the node, to ensure optimal
+infrastructure usage while also allowing some custom prioritisation of <code>GameServers</code>.</p>
+<p>For <code>Distributed</code> strategy scale down, the entire <code>Fleet</code> will be sorted by this priority list to provide the
+order of <code>GameServers</code> to delete on scale down.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code><br/>
+<em>
+<a href="#agones.dev/v1.GameServerTemplateSpec">
+GameServerTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<p>Template the GameServer template to apply for this Fleet</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#agones.dev/v1.FleetStatus">
+FleetStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.GameServer">GameServer
+</h3>
+<p>
+<p>GameServer is the data structure for a GameServer resource.
+It is worth noting that while there is a <code>GameServerStatus</code> Status entry for the <code>GameServer</code>, it is not
+defined as a subresource - unlike <code>Fleet</code> and other Agones resources.
+This is so that we can retain the ability to change multiple aspects of a <code>GameServer</code> in a single atomic operation,
+which is particularly useful for operations such as allocation.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+string</td>
+<td>
+<code>
+agones.dev/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br/>
+string
+</td>
+<td><code>GameServer</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://v1-35.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#agones.dev/v1.GameServerSpec">
+GameServerSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>container</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Container specifies which Pod container is the game server. Only required if there is more than one
+container defined</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ports</code><br/>
+<em>
+<a href="#agones.dev/v1.GameServerPort">
+[]GameServerPort
+</a>
+</em>
+</td>
+<td>
+<p>Ports are the array of ports that can be exposed via the game server</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>health</code><br/>
+<em>
+<a href="#agones.dev/v1.Health">
+Health
+</a>
+</em>
+</td>
+<td>
+<p>Health configures health checking</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scheduling</code><br/>
+<em>
+agones.dev/agones/pkg/apis.SchedulingStrategy
+</em>
+</td>
+<td>
+<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sdkServer</code><br/>
+<em>
+<a href="#agones.dev/v1.SdkServer">
+SdkServer
+</a>
+</em>
+</td>
+<td>
+<p>SdkServer specifies parameters for the Agones SDK Server sidecar container</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code><br/>
+<em>
+<a href="https://v1-35.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#podtemplatespec-v1-core">
+Kubernetes core/v1.PodTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<p>Template describes the Pod that will be created for the GameServer</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>players</code><br/>
+<em>
+<a href="#agones.dev/v1.PlayersSpec">
+PlayersSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>(Alpha, PlayerTracking feature flag) Players provides the configuration for player tracking features.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>counters</code><br/>
+<em>
+<a href="#agones.dev/v1.CounterStatus">
+map[string]agones.dev/agones/pkg/apis/agones/v1.CounterStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>(Beta, CountsAndLists feature flag) Counters provides the configuration for tracking of int64 values against a GameServer.
+Keys must be declared at GameServer creation time.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lists</code><br/>
+<em>
+<a href="#agones.dev/v1.ListStatus">
+map[string]agones.dev/agones/pkg/apis/agones/v1.ListStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>(Beta, CountsAndLists feature flag) Lists provides the configuration for tracking of lists of values against a GameServer,
+up to the maximum configured by the <code>gameservers.lists.maxItems</code> Helm value.
+Keys must be declared at GameServer creation time.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>eviction</code><br/>
+<em>
+<a href="#agones.dev/v1.Eviction">
+Eviction
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Eviction specifies the eviction tolerance of the GameServer. Defaults to &ldquo;Never&rdquo;.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#agones.dev/v1.GameServerStatus">
+GameServerStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.GameServerSet">GameServerSet
+</h3>
+<p>
+<p>GameServerSet is the data structure for a set of GameServers.
+This matches philosophically with the relationship between
+Deployments and ReplicaSets</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+string</td>
+<td>
+<code>
+agones.dev/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br/>
+string
+</td>
+<td><code>GameServerSet</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://v1-35.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#agones.dev/v1.GameServerSetSpec">
+GameServerSetSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>replicas</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>Replicas are the number of GameServers that should be in this set</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>allocationOverflow</code><br/>
+<em>
+<a href="#agones.dev/v1.AllocationOverflow">
+AllocationOverflow
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Labels and Annotations to apply to GameServers when the number of Allocated GameServers drops below
+the desired replicas on the underlying <code>GameServerSet</code></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scheduling</code><br/>
+<em>
+agones.dev/agones/pkg/apis.SchedulingStrategy
+</em>
+</td>
+<td>
+<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>priorities</code><br/>
+<em>
+<a href="#agones.dev/v1.Priority">
+[]Priority
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage: Beta]
+[FeatureFlag:CountsAndLists]
+<code>Priorities</code> configuration alters scale down logic in Fleets based on the configured available capacity order under that key.</p>
+<p>Priority of sorting is in descending importance. I.e. The position 0 <code>priority</code> entry is checked first.</p>
+<p>For <code>Packed</code> strategy scale down, this priority list will be the tie-breaker within the node, to ensure optimal
+infrastructure usage while also allowing some custom prioritisation of <code>GameServers</code>.</p>
+<p>For <code>Distributed</code> strategy scale down, the entire <code>Fleet</code> will be sorted by this priority list to provide the
+order of <code>GameServers</code> to delete on scale down.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code><br/>
+<em>
+<a href="#agones.dev/v1.GameServerTemplateSpec">
+GameServerTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<p>Template the GameServer template to apply for this GameServerSet</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#agones.dev/v1.GameServerSetStatus">
+GameServerSetStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.AggregatedCounterStatus">AggregatedCounterStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.FleetStatus">FleetStatus</a>, 
+<a href="#agones.dev/v1.GameServerSetStatus">GameServerSetStatus</a>)
+</p>
+<p>
+<p>AggregatedCounterStatus stores total and allocated Counter tracking values</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>allocatedCount</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>allocatedCapacity</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>count</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>capacity</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.AggregatedListStatus">AggregatedListStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.FleetStatus">FleetStatus</a>, 
+<a href="#agones.dev/v1.GameServerSetStatus">GameServerSetStatus</a>)
+</p>
+<p>
+<p>AggregatedListStatus stores total and allocated List tracking values</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>allocatedCount</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>allocatedCapacity</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>count</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>capacity</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.AggregatedPlayerStatus">AggregatedPlayerStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.FleetStatus">FleetStatus</a>, 
+<a href="#agones.dev/v1.GameServerSetStatus">GameServerSetStatus</a>)
+</p>
+<p>
+<p>AggregatedPlayerStatus stores total player tracking values</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>count</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>capacity</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.AllocationOverflow">AllocationOverflow
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.FleetSpec">FleetSpec</a>, 
+<a href="#agones.dev/v1.GameServerSetSpec">GameServerSetSpec</a>)
+</p>
+<p>
+<p>AllocationOverflow specifies what labels and/or annotations to apply on Allocated GameServers
+if the desired number of the underlying <code>GameServerSet</code> drops below the number of Allocated GameServers
+attached to it.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>labels</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Labels to be applied to the <code>GameServer</code></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>annotations</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Annotations to be applied to the <code>GameServer</code></p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.CounterStatus">CounterStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServerSpec">GameServerSpec</a>, 
+<a href="#agones.dev/v1.GameServerStatus">GameServerStatus</a>, 
+<a href="#allocation.agones.dev/v1.GameServerAllocationStatus">GameServerAllocationStatus</a>)
+</p>
+<p>
+<p>CounterStatus stores the current counter values and maximum capacity</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>count</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>capacity</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.Eviction">Eviction
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServerSpec">GameServerSpec</a>, 
+<a href="#agones.dev/v1.GameServerStatus">GameServerStatus</a>)
+</p>
+<p>
+<p>Eviction specifies the eviction tolerance of the GameServer</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>safe</code><br/>
+<em>
+<a href="#agones.dev/v1.EvictionSafe">
+EvictionSafe
+</a>
+</em>
+</td>
+<td>
+<p>Game server supports termination via SIGTERM:
+- Always: Allow eviction for both Cluster Autoscaler and node drain for upgrades
+- OnUpgrade: Allow eviction for upgrades alone
+- Never (default): Pod should run to completion</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.EvictionSafe">EvictionSafe
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.Eviction">Eviction</a>)
+</p>
+<p>
+<p>EvictionSafe specified whether the game server supports termination via SIGTERM</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;Always&#34;</p></td>
+<td><p>EvictionSafeAlways means the game server supports termination via SIGTERM, and wants eviction signals
+from Cluster Autoscaler scaledown and node upgrades.</p>
+</td>
+</tr><tr><td><p>&#34;Never&#34;</p></td>
+<td><p>EvictionSafeNever means the game server should run to completion and may not understand SIGTERM. Eviction
+from ClusterAutoscaler and upgrades should both be blocked.</p>
+</td>
+</tr><tr><td><p>&#34;OnUpgrade&#34;</p></td>
+<td><p>EvictionSafeOnUpgrade means the game server supports termination via SIGTERM, and wants eviction signals
+from node upgrades, but not Cluster Autoscaler scaledown.</p>
+</td>
+</tr></tbody>
+</table>
+<h3 id="agones.dev/v1.FleetSpec">FleetSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.Fleet">Fleet</a>)
+</p>
+<p>
+<p>FleetSpec is the spec for a Fleet</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>replicas</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>Replicas are the number of GameServers that should be in this set. Defaults to 0.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>allocationOverflow</code><br/>
+<em>
+<a href="#agones.dev/v1.AllocationOverflow">
+AllocationOverflow
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Labels and/or Annotations to apply to overflowing GameServers when the number of Allocated GameServers is more
+than the desired replicas on the underlying <code>GameServerSet</code></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>strategy</code><br/>
+<em>
+<a href="https://v1-35.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#deploymentstrategy-v1-apps">
+Kubernetes apps/v1.DeploymentStrategy
+</a>
+</em>
+</td>
+<td>
+<p>Deployment strategy</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scheduling</code><br/>
+<em>
+agones.dev/agones/pkg/apis.SchedulingStrategy
+</em>
+</td>
+<td>
+<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>priorities</code><br/>
+<em>
+<a href="#agones.dev/v1.Priority">
+[]Priority
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage: Beta]
+[FeatureFlag:CountsAndLists]
+<code>Priorities</code> configuration alters scale down logic in Fleets based on the configured available capacity order under that key.</p>
+<p>Priority of sorting is in descending importance. I.e. The position 0 <code>priority</code> entry is checked first.</p>
+<p>For <code>Packed</code> strategy scale down, this priority list will be the tie-breaker within the node, to ensure optimal
+infrastructure usage while also allowing some custom prioritisation of <code>GameServers</code>.</p>
+<p>For <code>Distributed</code> strategy scale down, the entire <code>Fleet</code> will be sorted by this priority list to provide the
+order of <code>GameServers</code> to delete on scale down.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code><br/>
+<em>
+<a href="#agones.dev/v1.GameServerTemplateSpec">
+GameServerTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<p>Template the GameServer template to apply for this Fleet</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.FleetStatus">FleetStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.Fleet">Fleet</a>, 
+<a href="#autoscaling.agones.dev/v1.FleetAutoscaleRequest">FleetAutoscaleRequest</a>)
+</p>
+<p>
+<p>FleetStatus is the status of a Fleet</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>replicas</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>Replicas the total number of current GameServer replicas</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>readyReplicas</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>ReadyReplicas are the number of Ready GameServer replicas</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reservedReplicas</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>ReservedReplicas are the total number of Reserved GameServer replicas in this fleet.
+Reserved instances won&rsquo;t be deleted on scale down, but won&rsquo;t cause an autoscaler to scale up.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>allocatedReplicas</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>AllocatedReplicas are the number of Allocated GameServer replicas</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>allocations</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<p>Allocations is a counter of the number of allocations observed.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>players</code><br/>
+<em>
+<a href="#agones.dev/v1.AggregatedPlayerStatus">
+AggregatedPlayerStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage:Alpha]
+[FeatureFlag:PlayerTracking]
+Players are the current total player capacity and count for this Fleet</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>counters</code><br/>
+<em>
+<a href="#agones.dev/v1.AggregatedCounterStatus">
+map[string]agones.dev/agones/pkg/apis/agones/v1.AggregatedCounterStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>(Beta, CountsAndLists feature flag) Counters provides aggregated Counter capacity and Counter
+count for this Fleet.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lists</code><br/>
+<em>
+<a href="#agones.dev/v1.AggregatedListStatus">
+map[string]agones.dev/agones/pkg/apis/agones/v1.AggregatedListStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>(Beta, CountsAndLists feature flag) Lists provides aggregated List capacityv and List values
+for this Fleet.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.GameServerPort">GameServerPort
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServerSpec">GameServerSpec</a>)
+</p>
+<p>
+<p>GameServerPort defines a set of Ports that
+are to be exposed via the GameServer</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is the descriptive name of the port</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>range</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Range is the port range name from which to select a port when using a
+&lsquo;Dynamic&rsquo; or &lsquo;Passthrough&rsquo; port policy.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>portPolicy</code><br/>
+<em>
+<a href="#agones.dev/v1.PortPolicy">
+PortPolicy
+</a>
+</em>
+</td>
+<td>
+<p>PortPolicy defines the policy for how the HostPort is populated.
+Dynamic port will allocate a HostPort within the selected MIN_PORT and MAX_PORT range passed to the controller
+at installation time.
+When <code>Static</code> portPolicy is specified, <code>HostPort</code> is required, to specify the port that game clients will
+connect to
+<code>Passthrough</code> dynamically sets the <code>containerPort</code> to the same value as the dynamically selected hostPort.
+<code>None</code> portPolicy ignores <code>HostPort</code> and the <code>containerPort</code> (optional) is used to set the port on the GameServer instance.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>container</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Container is the name of the container or sidecar container on which to open the port. Defaults to the game server container.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>containerPort</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>ContainerPort is the port that is being opened on the specified container&rsquo;s process</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>hostPort</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>HostPort the port exposed on the host for clients to connect to</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>protocol</code><br/>
+<em>
+<a href="https://v1-35.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#protocol-v1-core">
+Kubernetes core/v1.Protocol
+</a>
+</em>
+</td>
+<td>
+<p>Protocol is the network protocol being used. Defaults to UDP. TCP and TCPUDP are other options.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.GameServerSetSpec">GameServerSetSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServerSet">GameServerSet</a>)
+</p>
+<p>
+<p>GameServerSetSpec the specification for GameServerSet</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>replicas</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>Replicas are the number of GameServers that should be in this set</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>allocationOverflow</code><br/>
+<em>
+<a href="#agones.dev/v1.AllocationOverflow">
+AllocationOverflow
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Labels and Annotations to apply to GameServers when the number of Allocated GameServers drops below
+the desired replicas on the underlying <code>GameServerSet</code></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scheduling</code><br/>
+<em>
+agones.dev/agones/pkg/apis.SchedulingStrategy
+</em>
+</td>
+<td>
+<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>priorities</code><br/>
+<em>
+<a href="#agones.dev/v1.Priority">
+[]Priority
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage: Beta]
+[FeatureFlag:CountsAndLists]
+<code>Priorities</code> configuration alters scale down logic in Fleets based on the configured available capacity order under that key.</p>
+<p>Priority of sorting is in descending importance. I.e. The position 0 <code>priority</code> entry is checked first.</p>
+<p>For <code>Packed</code> strategy scale down, this priority list will be the tie-breaker within the node, to ensure optimal
+infrastructure usage while also allowing some custom prioritisation of <code>GameServers</code>.</p>
+<p>For <code>Distributed</code> strategy scale down, the entire <code>Fleet</code> will be sorted by this priority list to provide the
+order of <code>GameServers</code> to delete on scale down.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code><br/>
+<em>
+<a href="#agones.dev/v1.GameServerTemplateSpec">
+GameServerTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<p>Template the GameServer template to apply for this GameServerSet</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.GameServerSetStatus">GameServerSetStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServerSet">GameServerSet</a>)
+</p>
+<p>
+<p>GameServerSetStatus is the status of a GameServerSet</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>replicas</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>Replicas is the total number of current GameServer replicas</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>readyReplicas</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>ReadyReplicas is the number of Ready GameServer replicas</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reservedReplicas</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>ReservedReplicas is the number of Reserved GameServer replicas</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>allocatedReplicas</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>AllocatedReplicas is the number of Allocated GameServer replicas</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>shutdownReplicas</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>ShutdownReplicas is the number of Shutdown GameServers replicas</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>players</code><br/>
+<em>
+<a href="#agones.dev/v1.AggregatedPlayerStatus">
+AggregatedPlayerStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage:Alpha]
+[FeatureFlag:PlayerTracking]
+Players is the current total player capacity and count for this GameServerSet</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>counters</code><br/>
+<em>
+<a href="#agones.dev/v1.AggregatedCounterStatus">
+map[string]agones.dev/agones/pkg/apis/agones/v1.AggregatedCounterStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>(Beta, CountsAndLists feature flag) Counters provides aggregated Counter capacity and Counter
+count for this GameServerSet.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lists</code><br/>
+<em>
+<a href="#agones.dev/v1.AggregatedListStatus">
+map[string]agones.dev/agones/pkg/apis/agones/v1.AggregatedListStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>(Beta, CountsAndLists feature flag) Lists provides aggregated List capacity and List values
+for this GameServerSet.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.GameServerSpec">GameServerSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServer">GameServer</a>, 
+<a href="#agones.dev/v1.GameServerTemplateSpec">GameServerTemplateSpec</a>)
+</p>
+<p>
+<p>GameServerSpec is the spec for a GameServer resource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>container</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Container specifies which Pod container is the game server. Only required if there is more than one
+container defined</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ports</code><br/>
+<em>
+<a href="#agones.dev/v1.GameServerPort">
+[]GameServerPort
+</a>
+</em>
+</td>
+<td>
+<p>Ports are the array of ports that can be exposed via the game server</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>health</code><br/>
+<em>
+<a href="#agones.dev/v1.Health">
+Health
+</a>
+</em>
+</td>
+<td>
+<p>Health configures health checking</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scheduling</code><br/>
+<em>
+agones.dev/agones/pkg/apis.SchedulingStrategy
+</em>
+</td>
+<td>
+<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sdkServer</code><br/>
+<em>
+<a href="#agones.dev/v1.SdkServer">
+SdkServer
+</a>
+</em>
+</td>
+<td>
+<p>SdkServer specifies parameters for the Agones SDK Server sidecar container</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code><br/>
+<em>
+<a href="https://v1-35.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#podtemplatespec-v1-core">
+Kubernetes core/v1.PodTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<p>Template describes the Pod that will be created for the GameServer</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>players</code><br/>
+<em>
+<a href="#agones.dev/v1.PlayersSpec">
+PlayersSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>(Alpha, PlayerTracking feature flag) Players provides the configuration for player tracking features.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>counters</code><br/>
+<em>
+<a href="#agones.dev/v1.CounterStatus">
+map[string]agones.dev/agones/pkg/apis/agones/v1.CounterStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>(Beta, CountsAndLists feature flag) Counters provides the configuration for tracking of int64 values against a GameServer.
+Keys must be declared at GameServer creation time.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lists</code><br/>
+<em>
+<a href="#agones.dev/v1.ListStatus">
+map[string]agones.dev/agones/pkg/apis/agones/v1.ListStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>(Beta, CountsAndLists feature flag) Lists provides the configuration for tracking of lists of values against a GameServer,
+up to the maximum configured by the <code>gameservers.lists.maxItems</code> Helm value.
+Keys must be declared at GameServer creation time.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>eviction</code><br/>
+<em>
+<a href="#agones.dev/v1.Eviction">
+Eviction
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Eviction specifies the eviction tolerance of the GameServer. Defaults to &ldquo;Never&rdquo;.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.GameServerState">GameServerState
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServerStatus">GameServerStatus</a>, 
+<a href="#allocation.agones.dev/v1.GameServerSelector">GameServerSelector</a>)
+</p>
+<p>
+<p>GameServerState is the state for the GameServer</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;Allocated&#34;</p></td>
+<td><p>GameServerStateAllocated is when the GameServer has been allocated to a session</p>
+</td>
+</tr><tr><td><p>&#34;Creating&#34;</p></td>
+<td><p>GameServerStateCreating is before the Pod for the GameServer is being created</p>
+</td>
+</tr><tr><td><p>&#34;Error&#34;</p></td>
+<td><p>GameServerStateError is when something has gone wrong with the Gameserver and
+it cannot be resolved</p>
+</td>
+</tr><tr><td><p>&#34;PortAllocation&#34;</p></td>
+<td><p>GameServerStatePortAllocation is for when a dynamically allocating GameServer
+is being created, an open port needs to be allocated</p>
+</td>
+</tr><tr><td><p>&#34;Ready&#34;</p></td>
+<td><p>GameServerStateReady is when a GameServer is ready to take connections
+from Game clients</p>
+</td>
+</tr><tr><td><p>&#34;RequestReady&#34;</p></td>
+<td><p>GameServerStateRequestReady is when the GameServer has declared that it is ready</p>
+</td>
+</tr><tr><td><p>&#34;Reserved&#34;</p></td>
+<td><p>GameServerStateReserved is for when a GameServer is reserved and therefore can be allocated but not removed</p>
+</td>
+</tr><tr><td><p>&#34;Scheduled&#34;</p></td>
+<td><p>GameServerStateScheduled is for when we have determined that the Pod has been
+scheduled in the cluster &ndash; basically, we have a NodeName</p>
+</td>
+</tr><tr><td><p>&#34;Shutdown&#34;</p></td>
+<td><p>GameServerStateShutdown is when the GameServer has shutdown and everything needs to be
+deleted from the cluster</p>
+</td>
+</tr><tr><td><p>&#34;Starting&#34;</p></td>
+<td><p>GameServerStateStarting is for when the Pods for the GameServer are being
+created but are not yet Scheduled</p>
+</td>
+</tr><tr><td><p>&#34;Unhealthy&#34;</p></td>
+<td><p>GameServerStateUnhealthy is when the GameServer has failed its health checks</p>
+</td>
+</tr></tbody>
+</table>
+<h3 id="agones.dev/v1.GameServerStatus">GameServerStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServer">GameServer</a>)
+</p>
+<p>
+<p>GameServerStatus is the status for a GameServer resource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>state</code><br/>
+<em>
+<a href="#agones.dev/v1.GameServerState">
+GameServerState
+</a>
+</em>
+</td>
+<td>
+<p>GameServerState is the current state of a GameServer, e.g. Creating, Starting, Ready, etc</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ports</code><br/>
+<em>
+<a href="#agones.dev/v1.GameServerStatusPort">
+[]GameServerStatusPort
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>address</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>addresses</code><br/>
+<em>
+<a href="https://v1-35.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeaddress-v1-core">
+[]Kubernetes core/v1.NodeAddress
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Addresses is the array of addresses at which the GameServer can be reached; copy of Node.Status.addresses.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>reservedUntil</code><br/>
+<em>
+<a href="https://v1-35.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>players</code><br/>
+<em>
+<a href="#agones.dev/v1.PlayerStatus">
+PlayerStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage:Alpha]
+[FeatureFlag:PlayerTracking]</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>counters</code><br/>
+<em>
+<a href="#agones.dev/v1.CounterStatus">
+map[string]agones.dev/agones/pkg/apis/agones/v1.CounterStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>(Beta, CountsAndLists feature flag) Counters and Lists provides the configuration for generic tracking features.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lists</code><br/>
+<em>
+<a href="#agones.dev/v1.ListStatus">
+map[string]agones.dev/agones/pkg/apis/agones/v1.ListStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>eviction</code><br/>
+<em>
+<a href="#agones.dev/v1.Eviction">
+Eviction
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Eviction specifies the eviction tolerance of the GameServer.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.GameServerStatusPort">GameServerStatusPort
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServerStatus">GameServerStatus</a>, 
+<a href="#allocation.agones.dev/v1.GameServerAllocationStatus">GameServerAllocationStatus</a>)
+</p>
+<p>
+<p>GameServerStatusPort shows the port that was allocated to a
+GameServer.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>port</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.GameServerTemplateSpec">GameServerTemplateSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.FleetSpec">FleetSpec</a>, 
+<a href="#agones.dev/v1.GameServerSetSpec">GameServerSetSpec</a>)
+</p>
+<p>
+<p>GameServerTemplateSpec is a template for GameServers</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://v1-35.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#agones.dev/v1.GameServerSpec">
+GameServerSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>container</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Container specifies which Pod container is the game server. Only required if there is more than one
+container defined</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ports</code><br/>
+<em>
+<a href="#agones.dev/v1.GameServerPort">
+[]GameServerPort
+</a>
+</em>
+</td>
+<td>
+<p>Ports are the array of ports that can be exposed via the game server</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>health</code><br/>
+<em>
+<a href="#agones.dev/v1.Health">
+Health
+</a>
+</em>
+</td>
+<td>
+<p>Health configures health checking</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scheduling</code><br/>
+<em>
+agones.dev/agones/pkg/apis.SchedulingStrategy
+</em>
+</td>
+<td>
+<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sdkServer</code><br/>
+<em>
+<a href="#agones.dev/v1.SdkServer">
+SdkServer
+</a>
+</em>
+</td>
+<td>
+<p>SdkServer specifies parameters for the Agones SDK Server sidecar container</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code><br/>
+<em>
+<a href="https://v1-35.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#podtemplatespec-v1-core">
+Kubernetes core/v1.PodTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<p>Template describes the Pod that will be created for the GameServer</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>players</code><br/>
+<em>
+<a href="#agones.dev/v1.PlayersSpec">
+PlayersSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>(Alpha, PlayerTracking feature flag) Players provides the configuration for player tracking features.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>counters</code><br/>
+<em>
+<a href="#agones.dev/v1.CounterStatus">
+map[string]agones.dev/agones/pkg/apis/agones/v1.CounterStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>(Beta, CountsAndLists feature flag) Counters provides the configuration for tracking of int64 values against a GameServer.
+Keys must be declared at GameServer creation time.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lists</code><br/>
+<em>
+<a href="#agones.dev/v1.ListStatus">
+map[string]agones.dev/agones/pkg/apis/agones/v1.ListStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>(Beta, CountsAndLists feature flag) Lists provides the configuration for tracking of lists of values against a GameServer,
+up to the maximum configured by the <code>gameservers.lists.maxItems</code> Helm value.
+Keys must be declared at GameServer creation time.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>eviction</code><br/>
+<em>
+<a href="#agones.dev/v1.Eviction">
+Eviction
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Eviction specifies the eviction tolerance of the GameServer. Defaults to &ldquo;Never&rdquo;.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.Health">Health
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServerSpec">GameServerSpec</a>)
+</p>
+<p>
+<p>Health configures health checking on the GameServer</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>disabled</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>Disabled is whether health checking is disabled or not</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>periodSeconds</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>PeriodSeconds is the number of seconds each health ping has to occur in</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>failureThreshold</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>FailureThreshold how many failures in a row constitutes unhealthy</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>initialDelaySeconds</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>InitialDelaySeconds initial delay before checking health</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.ListStatus">ListStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServerSpec">GameServerSpec</a>, 
+<a href="#agones.dev/v1.GameServerStatus">GameServerStatus</a>, 
+<a href="#allocation.agones.dev/v1.GameServerAllocationStatus">GameServerAllocationStatus</a>)
+</p>
+<p>
+<p>ListStatus stores the current list values and maximum capacity</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>capacity</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>values</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.PlayerStatus">PlayerStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServerStatus">GameServerStatus</a>)
+</p>
+<p>
+<p>PlayerStatus stores the current player capacity values</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>count</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>capacity</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>ids</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.PlayersSpec">PlayersSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServerSpec">GameServerSpec</a>)
+</p>
+<p>
+<p>PlayersSpec tracks the initial player capacity</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>initialCapacity</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.PortPolicy">PortPolicy
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServerPort">GameServerPort</a>)
+</p>
+<p>
+<p>PortPolicy is the port policy for the GameServer</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;Dynamic&#34;</p></td>
+<td><p>Dynamic PortPolicy means that the system will choose an open
+port for the GameServer in question</p>
+</td>
+</tr><tr><td><p>&#34;None&#34;</p></td>
+<td><p>None means the <code>hostPort</code> is ignored and if defined, the <code>containerPort</code> (optional) is used to set the port on the GameServer instance.</p>
+</td>
+</tr><tr><td><p>&#34;Passthrough&#34;</p></td>
+<td><p>Passthrough dynamically sets the <code>containerPort</code> to the same value as the dynamically selected hostPort.
+This will mean that users will need to lookup what port has been opened through the server side SDK.</p>
+</td>
+</tr><tr><td><p>&#34;Static&#34;</p></td>
+<td><p>Static PortPolicy means that the user defines the hostPort to be used
+in the configuration.</p>
+</td>
+</tr></tbody>
+</table>
+<h3 id="agones.dev/v1.Priority">Priority
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.FleetSpec">FleetSpec</a>, 
+<a href="#agones.dev/v1.GameServerSetSpec">GameServerSetSpec</a>, 
+<a href="#allocation.agones.dev/v1.GameServerAllocationSpec">GameServerAllocationSpec</a>)
+</p>
+<p>
+<p>Priority is a sorting option for GameServers with Counters or Lists based on the available capacity,
+i.e. the current Capacity value, minus either the Count value or List length.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>type</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Type: Sort by a &ldquo;Counter&rdquo; or a &ldquo;List&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>key</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Key: The name of the Counter or List. If not found on the GameServer, has no impact.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>order</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Order: Sort by &ldquo;Ascending&rdquo; or &ldquo;Descending&rdquo;. &ldquo;Descending&rdquo; a bigger available capacity is preferred.
+&ldquo;Ascending&rdquo; would be smaller available capacity is preferred.
+The default sort order is &ldquo;Ascending&rdquo;</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.SdkServer">SdkServer
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.GameServerSpec">GameServerSpec</a>)
+</p>
+<p>
+<p>SdkServer specifies parameters for the Agones SDK Server sidecar container</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>logLevel</code><br/>
+<em>
+<a href="#agones.dev/v1.SdkServerLogLevel">
+SdkServerLogLevel
+</a>
+</em>
+</td>
+<td>
+<p>LogLevel for SDK server (sidecar) logs. Defaults to &ldquo;Info&rdquo;</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>grpcPort</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>GRPCPort is the port on which the SDK Server binds the gRPC server to accept incoming connections</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>httpPort</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>HTTPPort is the port on which the SDK Server binds the HTTP gRPC gateway server to accept incoming connections</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="agones.dev/v1.SdkServerLogLevel">SdkServerLogLevel
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#agones.dev/v1.SdkServer">SdkServer</a>)
+</p>
+<p>
+<p>SdkServerLogLevel is the log level for SDK server (sidecar) logs</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;Debug&#34;</p></td>
+<td><p>SdkServerLogLevelDebug will cause the SDK server to output all messages including debug messages.</p>
+</td>
+</tr><tr><td><p>&#34;Error&#34;</p></td>
+<td><p>SdkServerLogLevelError will cause the SDK server to only output error messages.</p>
+</td>
+</tr><tr><td><p>&#34;Info&#34;</p></td>
+<td><p>SdkServerLogLevelInfo will cause the SDK server to output all messages except for debug messages.</p>
+</td>
+</tr><tr><td><p>&#34;Trace&#34;</p></td>
+<td><p>SdkServerLogLevelTrace will cause the SDK server to output all messages, including detailed tracing information.</p>
+</td>
+</tr></tbody>
+</table>
+<hr/>
+<h2 id="allocation.agones.dev/v1">allocation.agones.dev/v1</h2>
+<p>
+<p>Package v1 is the v1 version of the API.</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#allocation.agones.dev/v1.GameServerAllocation">GameServerAllocation</a>
+</li></ul>
+<h3 id="allocation.agones.dev/v1.GameServerAllocation">GameServerAllocation
+</h3>
+<p>
+<p>GameServerAllocation is the data structure for allocating against a set of
+GameServers, defined <code>selectors</code> selectors</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+string</td>
+<td>
+<code>
+allocation.agones.dev/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br/>
+string
+</td>
+<td><code>GameServerAllocation</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://v1-35.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.GameServerAllocationSpec">
+GameServerAllocationSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>multiClusterSetting</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.MultiClusterSetting">
+MultiClusterSetting
+</a>
+</em>
+</td>
+<td>
+<p>MultiClusterPolicySelector if specified, multi-cluster policies are applied.
+Otherwise, allocation will happen locally.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>required</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.GameServerSelector">
+GameServerSelector
+</a>
+</em>
+</td>
+<td>
+<p>Deprecated: use field Selectors instead. If Selectors is set, this field is ignored.
+Required is the GameServer selector from which to choose GameServers from.
+Defaults to all GameServers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>preferred</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.GameServerSelector">
+[]GameServerSelector
+</a>
+</em>
+</td>
+<td>
+<p>Deprecated: use field Selectors instead. If Selectors is set, this field is ignored.
+Preferred is an ordered list of preferred GameServer selectors
+that are optional to be fulfilled, but will be searched before the <code>required</code> selector.
+If the first selector is not matched, the selection attempts the second selector, and so on.
+If any of the preferred selectors are matched, the required selector is not considered.
+This is useful for things like smoke testing of new game servers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>priorities</code><br/>
+<em>
+<a href="#agones.dev/v1.Priority">
+[]Priority
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage: Beta]
+[FeatureFlag:CountsAndLists]
+<code>Priorities</code> configuration alters the order in which <code>GameServers</code> are searched for matches to the configured <code>selectors</code>.</p>
+<p>Priority of sorting is in descending importance. I.e. The position 0 <code>priority</code> entry is checked first.</p>
+<p>For <code>Packed</code> strategy sorting, this priority list will be the tie-breaker within the least utilised infrastructure, to ensure optimal
+infrastructure usage while also allowing some custom prioritisation of <code>GameServers</code>.</p>
+<p>For <code>Distributed</code> strategy sorting, the entire selection of <code>GameServers</code> will be sorted by this priority list to provide the
+order that <code>GameServers</code> will be allocated by.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>selectors</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.GameServerSelector">
+[]GameServerSelector
+</a>
+</em>
+</td>
+<td>
+<p>Ordered list of GameServer label selectors.
+If the first selector is not matched, the selection attempts the second selector, and so on.
+This is useful for things like smoke testing of new game servers.
+Note: This field can only be set if neither Required or Preferred is set.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scheduling</code><br/>
+<em>
+agones.dev/agones/pkg/apis.SchedulingStrategy
+</em>
+</td>
+<td>
+<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.MetaPatch">
+MetaPatch
+</a>
+</em>
+</td>
+<td>
+<p>MetaPatch is optional custom metadata that is added to the game server at allocation
+You can use this to tell the server necessary session data</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>counters</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.CounterAction">
+map[string]agones.dev/agones/pkg/apis/allocation/v1.CounterAction
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage: Beta]
+[FeatureFlag:CountsAndLists]
+Counter actions to perform during allocation.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lists</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.ListAction">
+map[string]agones.dev/agones/pkg/apis/allocation/v1.ListAction
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage: Beta]
+[FeatureFlag:CountsAndLists]
+List actions to perform during allocation.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.GameServerAllocationStatus">
+GameServerAllocationStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="allocation.agones.dev/v1.CounterAction">CounterAction
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#allocation.agones.dev/v1.GameServerAllocationSpec">GameServerAllocationSpec</a>)
+</p>
+<p>
+<p>CounterAction is an optional action that can be performed on a Counter at allocation.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>action</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Action must to either &ldquo;Increment&rdquo; or &ldquo;Decrement&rdquo; the Counter&rsquo;s Count. Must also define the Amount.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>amount</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Amount is the amount to increment or decrement the Count. Must be a positive integer.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>capacity</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Capacity is the amount to update the maximum capacity of the Counter to this number. Min 0, Max int64.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="allocation.agones.dev/v1.CounterSelector">CounterSelector
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#allocation.agones.dev/v1.GameServerSelector">GameServerSelector</a>)
+</p>
+<p>
+<p>CounterSelector is the filter options for a GameServer based on the count and/or available capacity.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>minCount</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MinCount is the minimum current value. Defaults to 0.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>maxCount</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MaxCount is the maximum current value. Defaults to 0, which translates as max(in64).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>minAvailable</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MinAvailable specifies the minimum capacity (current capacity - current count) available on a GameServer. Defaults to 0.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>maxAvailable</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MaxAvailable specifies the maximum capacity (current capacity - current count) available on a GameServer. Defaults to 0, which translates to max(int64).</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="allocation.agones.dev/v1.GameServerAllocationSpec">GameServerAllocationSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#allocation.agones.dev/v1.GameServerAllocation">GameServerAllocation</a>)
+</p>
+<p>
+<p>GameServerAllocationSpec is the spec for a GameServerAllocation</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>multiClusterSetting</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.MultiClusterSetting">
+MultiClusterSetting
+</a>
+</em>
+</td>
+<td>
+<p>MultiClusterPolicySelector if specified, multi-cluster policies are applied.
+Otherwise, allocation will happen locally.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>required</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.GameServerSelector">
+GameServerSelector
+</a>
+</em>
+</td>
+<td>
+<p>Deprecated: use field Selectors instead. If Selectors is set, this field is ignored.
+Required is the GameServer selector from which to choose GameServers from.
+Defaults to all GameServers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>preferred</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.GameServerSelector">
+[]GameServerSelector
+</a>
+</em>
+</td>
+<td>
+<p>Deprecated: use field Selectors instead. If Selectors is set, this field is ignored.
+Preferred is an ordered list of preferred GameServer selectors
+that are optional to be fulfilled, but will be searched before the <code>required</code> selector.
+If the first selector is not matched, the selection attempts the second selector, and so on.
+If any of the preferred selectors are matched, the required selector is not considered.
+This is useful for things like smoke testing of new game servers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>priorities</code><br/>
+<em>
+<a href="#agones.dev/v1.Priority">
+[]Priority
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage: Beta]
+[FeatureFlag:CountsAndLists]
+<code>Priorities</code> configuration alters the order in which <code>GameServers</code> are searched for matches to the configured <code>selectors</code>.</p>
+<p>Priority of sorting is in descending importance. I.e. The position 0 <code>priority</code> entry is checked first.</p>
+<p>For <code>Packed</code> strategy sorting, this priority list will be the tie-breaker within the least utilised infrastructure, to ensure optimal
+infrastructure usage while also allowing some custom prioritisation of <code>GameServers</code>.</p>
+<p>For <code>Distributed</code> strategy sorting, the entire selection of <code>GameServers</code> will be sorted by this priority list to provide the
+order that <code>GameServers</code> will be allocated by.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>selectors</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.GameServerSelector">
+[]GameServerSelector
+</a>
+</em>
+</td>
+<td>
+<p>Ordered list of GameServer label selectors.
+If the first selector is not matched, the selection attempts the second selector, and so on.
+This is useful for things like smoke testing of new game servers.
+Note: This field can only be set if neither Required or Preferred is set.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scheduling</code><br/>
+<em>
+agones.dev/agones/pkg/apis.SchedulingStrategy
+</em>
+</td>
+<td>
+<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.MetaPatch">
+MetaPatch
+</a>
+</em>
+</td>
+<td>
+<p>MetaPatch is optional custom metadata that is added to the game server at allocation
+You can use this to tell the server necessary session data</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>counters</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.CounterAction">
+map[string]agones.dev/agones/pkg/apis/allocation/v1.CounterAction
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage: Beta]
+[FeatureFlag:CountsAndLists]
+Counter actions to perform during allocation.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lists</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.ListAction">
+map[string]agones.dev/agones/pkg/apis/allocation/v1.ListAction
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage: Beta]
+[FeatureFlag:CountsAndLists]
+List actions to perform during allocation.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="allocation.agones.dev/v1.GameServerAllocationState">GameServerAllocationState
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#allocation.agones.dev/v1.GameServerAllocationStatus">GameServerAllocationStatus</a>)
+</p>
+<p>
+<p>GameServerAllocationState is the Allocation state</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;Allocated&#34;</p></td>
+<td><p>GameServerAllocationAllocated is allocation successful</p>
+</td>
+</tr><tr><td><p>&#34;Contention&#34;</p></td>
+<td><p>GameServerAllocationContention when the allocation is unsuccessful
+because of contention</p>
+</td>
+</tr><tr><td><p>&#34;UnAllocated&#34;</p></td>
+<td><p>GameServerAllocationUnAllocated when the allocation is unsuccessful</p>
+</td>
+</tr></tbody>
+</table>
+<h3 id="allocation.agones.dev/v1.GameServerAllocationStatus">GameServerAllocationStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#allocation.agones.dev/v1.GameServerAllocation">GameServerAllocation</a>)
+</p>
+<p>
+<p>GameServerAllocationStatus is the status for an GameServerAllocation resource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>state</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.GameServerAllocationState">
+GameServerAllocationState
+</a>
+</em>
+</td>
+<td>
+<p>GameServerState is the current state of an GameServerAllocation, e.g. Allocated, or UnAllocated</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>gameServerName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>ports</code><br/>
+<em>
+<a href="#agones.dev/v1.GameServerStatusPort">
+[]GameServerStatusPort
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>address</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>addresses</code><br/>
+<em>
+<a href="https://v1-35.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#nodeaddress-v1-core">
+[]Kubernetes core/v1.NodeAddress
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>source</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>If the allocation is from a remote cluster, Source is the endpoint of the remote agones-allocator.
+Otherwise, Source is &ldquo;local&rdquo;</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.GameServerMetadata">
+GameServerMetadata
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>counters</code><br/>
+<em>
+<a href="#agones.dev/v1.CounterStatus">
+map[string]agones.dev/agones/pkg/apis/agones/v1.CounterStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>lists</code><br/>
+<em>
+<a href="#agones.dev/v1.ListStatus">
+map[string]agones.dev/agones/pkg/apis/agones/v1.ListStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="allocation.agones.dev/v1.GameServerMetadata">GameServerMetadata
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#allocation.agones.dev/v1.GameServerAllocationStatus">GameServerAllocationStatus</a>)
+</p>
+<p>
+<p>GameServerMetadata is the metadata from the allocated game server at allocation time</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>labels</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>annotations</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="allocation.agones.dev/v1.GameServerSelector">GameServerSelector
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#allocation.agones.dev/v1.GameServerAllocationSpec">GameServerAllocationSpec</a>)
+</p>
+<p>
+<p>GameServerSelector contains all the filter options for selecting
+a GameServer for allocation.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>LabelSelector</code><br/>
+<em>
+<a href="https://v1-35.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselector-v1-meta">
+Kubernetes meta/v1.LabelSelector
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>LabelSelector</code> are embedded into this type.)
+</p>
+<p>See: <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/">https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>gameServerState</code><br/>
+<em>
+<a href="#agones.dev/v1.GameServerState">
+GameServerState
+</a>
+</em>
+</td>
+<td>
+<p>GameServerState specifies which State is the filter to be used when attempting to retrieve a GameServer
+via Allocation. Defaults to &ldquo;Ready&rdquo;. The only other option is &ldquo;Allocated&rdquo;, which can be used in conjunction with
+label/annotation/player selectors to retrieve an already Allocated GameServer.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>counters</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.CounterSelector">
+map[string]agones.dev/agones/pkg/apis/allocation/v1.CounterSelector
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage: Beta]
+[FeatureFlag:CountsAndLists]
+Counters provides filters on minimum and maximum values
+for a Counter&rsquo;s count and available capacity when retrieving a GameServer through Allocation.
+Defaults to no limits.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lists</code><br/>
+<em>
+<a href="#allocation.agones.dev/v1.ListSelector">
+map[string]agones.dev/agones/pkg/apis/allocation/v1.ListSelector
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage: Beta]
+[FeatureFlag:CountsAndLists]
+Lists provides filters on minimum and maximum values
+for List capacity, and for the existence of a value in a List, when retrieving a GameServer
+through Allocation. Defaults to no limits.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="allocation.agones.dev/v1.ListAction">ListAction
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#allocation.agones.dev/v1.GameServerAllocationSpec">GameServerAllocationSpec</a>)
+</p>
+<p>
+<p>ListAction is an optional action that can be performed on a List at allocation.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>addValues</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>AddValues appends values to a List&rsquo;s Values array. Any duplicate values will be ignored.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>deleteValues</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeleteValues removes values from a List&rsquo;s Values array. Any nonexistant values will be ignored.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>capacity</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Capacity updates the maximum capacity of the Counter to this number. Min 0, Max 1000.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="allocation.agones.dev/v1.ListSelector">ListSelector
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#allocation.agones.dev/v1.GameServerSelector">GameServerSelector</a>)
+</p>
+<p>
+<p>ListSelector is the filter options for a GameServer based on List available capacity and/or the
+existence of a value in a List.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>containsValue</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ContainsValue says to only match GameServers who has this value in the list. Defaults to &ldquo;&rdquo;, which is all.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>minAvailable</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MinAvailable specifies the minimum capacity (current capacity - current count) available on a GameServer. Defaults to 0.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>maxAvailable</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MaxAvailable specifies the maximum capacity (current capacity - current count) available on a GameServer. Defaults to 0, which is translated as max(int64).</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="allocation.agones.dev/v1.MetaPatch">MetaPatch
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#allocation.agones.dev/v1.GameServerAllocationSpec">GameServerAllocationSpec</a>)
+</p>
+<p>
+<p>MetaPatch is the metadata used to patch the GameServer metadata on allocation</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>labels</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>annotations</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="allocation.agones.dev/v1.MultiClusterSetting">MultiClusterSetting
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#allocation.agones.dev/v1.GameServerAllocationSpec">GameServerAllocationSpec</a>)
+</p>
+<p>
+<p>MultiClusterSetting specifies settings for multi-cluster allocation.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>enabled</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>policySelector</code><br/>
+<em>
+<a href="https://v1-35.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselector-v1-meta">
+Kubernetes meta/v1.LabelSelector
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="autoscaling.agones.dev/v1">autoscaling.agones.dev/v1</h2>
+<p>
+<p>Package v1 is the v1 version of the API.</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscaler">FleetAutoscaler</a>
+</li></ul>
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscaler">FleetAutoscaler
+</h3>
+<p>
+<p>FleetAutoscaler is the data structure for a FleetAutoscaler resource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+string</td>
+<td>
+<code>
+autoscaling.agones.dev/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br/>
+string
+</td>
+<td><code>FleetAutoscaler</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://v1-35.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSpec">
+FleetAutoscalerSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>fleetName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>policy</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">
+FleetAutoscalerPolicy
+</a>
+</em>
+</td>
+<td>
+<p>Autoscaling policy</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sync</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSync">
+FleetAutoscalerSync
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Sync defines when FleetAutoscalers runs autoscaling</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerStatus">
+FleetAutoscalerStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.ActivePeriod">ActivePeriod
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.SchedulePolicy">SchedulePolicy</a>)
+</p>
+<p>
+<p>ActivePeriod defines the time period that the policy is applied.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>timezone</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Timezone to be used for the startCron field. If not set, startCron is defaulted to the UTC timezone.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>startCron</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>StartCron defines when the policy should be applied.
+If not set, the policy is always to be applied within the start and end time.
+This field must conform to UNIX cron syntax.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>duration</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Duration is the length of time that the policy is applied.
+If not set, the duration is indefinite.
+A duration string is a possibly signed sequence of decimal numbers,
+(e.g. &ldquo;300ms&rdquo;, &ldquo;-1.5h&rdquo; or &ldquo;2h45m&rdquo;).
+The representation limits the largest representable duration to approximately 290 years.
+Valid time units are &ldquo;ns&rdquo;, &ldquo;us&rdquo; (or &ldquo;µs&rdquo;), &ldquo;ms&rdquo;, &ldquo;s&rdquo;, &ldquo;m&rdquo;, &ldquo;h&rdquo;.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.Between">Between
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.SchedulePolicy">SchedulePolicy</a>)
+</p>
+<p>
+<p>Between defines the time period that the policy is eligible to be applied.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>start</code><br/>
+<em>
+<a href="https://v1-35.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<p>Start is the datetime that the policy is eligible to be applied.
+This field must conform to RFC3339 format. If this field not set or is in the past, the policy is eligible to be applied
+as soon as the fleet autoscaler is running.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>end</code><br/>
+<em>
+<a href="https://v1-35.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<p>End is the datetime that the policy is no longer eligible to be applied.
+This field must conform to RFC3339 format. If not set, the policy is always eligible to be applied, after the start time above.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.BufferPolicy">BufferPolicy
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
+</p>
+<p>
+<p>BufferPolicy controls the desired behavior of the buffer policy.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>maxReplicas</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>MaxReplicas is the maximum amount of replicas that the fleet may have.
+It must be bigger than both MinReplicas and BufferSize</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>minReplicas</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>MinReplicas is the minimum amount of replicas that the fleet must have
+If zero, it is ignored.
+If non zero, it must be smaller than MaxReplicas and bigger than BufferSize</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>bufferSize</code><br/>
+<em>
+k8s.io/apimachinery/pkg/util/intstr.IntOrString
+</em>
+</td>
+<td>
+<p>BufferSize defines how many replicas the autoscaler tries to have ready all the time
+Value can be an absolute number (ex: 5) or a percentage of desired gs instances (ex: 15%)
+Absolute number is calculated from percentage by rounding up.
+Example: when this is set to 20%, the autoscaler will make sure that 20%
+of the fleet&rsquo;s game server replicas are ready. When this is set to 20,
+the autoscaler will make sure that there are 20 available game servers
+Must be bigger than 0
+Note: by &ldquo;ready&rdquo; we understand in this case &ldquo;non-allocated&rdquo;; this is done to ensure robustness
+and computation stability in different edge case (fleet just created, not enough
+capacity in the cluster etc)</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.ChainEntry">ChainEntry
+</h3>
+<p>
+<p>ChainEntry defines a single entry in the ChainPolicy.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>id</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>ID is the unique identifier for a ChainEntry. If not set the identifier will be set to the index of chain entry.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>FleetAutoscalerPolicy</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">
+FleetAutoscalerPolicy
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>FleetAutoscalerPolicy</code> are embedded into this type.)
+</p>
+<p>Policy is the name of the policy to be applied. Required field.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.ChainPolicy">ChainPolicy
+(<code>[]agones.dev/agones/pkg/apis/autoscaling/v1.ChainEntry</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
+</p>
+<p>
+<p>ChainPolicy controls the desired behavior of the Chain autoscaler policy.</p>
+</p>
+<h3 id="autoscaling.agones.dev/v1.CounterPolicy">CounterPolicy
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
+</p>
+<p>
+<p>CounterPolicy controls the desired behavior of the Counter autoscaler policy.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>key</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Key is the name of the Counter. Required field.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>maxCapacity</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<p>MaxCapacity is the maximum aggregate Counter total capacity across the fleet.
+MaxCapacity must be bigger than both MinCapacity and BufferSize. Required field.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>minCapacity</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<p>MinCapacity is the minimum aggregate Counter total capacity across the fleet.
+If zero, MinCapacity is ignored.
+If non zero, MinCapacity must be smaller than MaxCapacity and bigger than BufferSize.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>bufferSize</code><br/>
+<em>
+k8s.io/apimachinery/pkg/util/intstr.IntOrString
+</em>
+</td>
+<td>
+<p>BufferSize is the size of a buffer of counted items that are available in the Fleet (available
+capacity). Value can be an absolute number (ex: 5) or a percentage of desired gs instances
+(ex: 5%). An absolute number is calculated from percentage by rounding up.
+Must be bigger than 0. Required field.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.FixedIntervalSync">FixedIntervalSync
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSync">FleetAutoscalerSync</a>)
+</p>
+<p>
+<p>FixedIntervalSync controls the desired behavior of the fixed interval based sync.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>seconds</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>Seconds defines how often we run fleet autoscaling in seconds</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscaleRequest">FleetAutoscaleRequest
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscaleReview">FleetAutoscaleReview</a>)
+</p>
+<p>
+<p>FleetAutoscaleRequest defines the request to webhook autoscaler endpoint</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>uid</code><br/>
+<em>
+k8s.io/apimachinery/pkg/types.UID
+</em>
+</td>
+<td>
+<p>UID is an identifier for the individual request/response. It allows us to distinguish instances of requests which are
+otherwise identical (parallel requests, requests when earlier requests did not modify etc)
+The UID is meant to track the round trip (request/response) between the Autoscaler and the WebHook, not the user request.
+It is suitable for correlating log entries between the webhook and apiserver, for either auditing or debugging.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is the name of the Fleet being scaled</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>namespace</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Namespace is the namespace associated with the request (if any).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#agones.dev/v1.FleetStatus">
+FleetStatus
+</a>
+</em>
+</td>
+<td>
+<p>The Fleet&rsquo;s status values</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>labels</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<p>Standard map labels; More info: <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/labels">https://kubernetes.io/docs/concepts/overview/working-with-objects/labels</a>.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>annotations</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<p>Standard map annotations; More info: <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations">https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations</a>.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscaleResponse">FleetAutoscaleResponse
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscaleReview">FleetAutoscaleReview</a>)
+</p>
+<p>
+<p>FleetAutoscaleResponse defines the response of webhook autoscaler endpoint</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>uid</code><br/>
+<em>
+k8s.io/apimachinery/pkg/types.UID
+</em>
+</td>
+<td>
+<p>UID is an identifier for the individual request/response.
+This should be copied over from the corresponding FleetAutoscaleRequest.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scale</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>Set to false if no scaling should occur to the Fleet</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>replicas</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>The targeted replica count</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscaleReview">FleetAutoscaleReview
+</h3>
+<p>
+<p>FleetAutoscaleReview is passed to the webhook with a populated Request value,
+and then returned with a populated Response.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>request</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscaleRequest">
+FleetAutoscaleRequest
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>response</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscaleResponse">
+FleetAutoscaleResponse
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.ChainEntry">ChainEntry</a>, 
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSpec">FleetAutoscalerSpec</a>, 
+<a href="#autoscaling.agones.dev/v1.SchedulePolicy">SchedulePolicy</a>)
+</p>
+<p>
+<p>FleetAutoscalerPolicy describes how to scale a fleet</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>type</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicyType">
+FleetAutoscalerPolicyType
+</a>
+</em>
+</td>
+<td>
+<p>Type of autoscaling policy.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>buffer</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.BufferPolicy">
+BufferPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Buffer policy config params. Present only if FleetAutoscalerPolicyType = Buffer.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>webhook</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.URLConfiguration">
+URLConfiguration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Webhook policy config params. Present only if FleetAutoscalerPolicyType = Webhook.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>counter</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.CounterPolicy">
+CounterPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage:Beta]
+[FeatureFlag:CountsAndLists]
+Counter policy config params. Present only if FleetAutoscalerPolicyType = Counter.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>list</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.ListPolicy">
+ListPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage:Beta]
+[FeatureFlag:CountsAndLists]
+List policy config params. Present only if FleetAutoscalerPolicyType = List.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>schedule</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.SchedulePolicy">
+SchedulePolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage:Beta]
+[FeatureFlag:ScheduledAutoscaler]
+Schedule policy config params. Present only if FleetAutoscalerPolicyType = Schedule.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>chain</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.ChainPolicy">
+ChainPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>[Stage:Beta]
+[FeatureFlag:ScheduledAutoscaler]
+Chain policy config params. Present only if FleetAutoscalerPolicyType = Chain.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>wasm</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.WasmPolicy">
+WasmPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Wasm policy config params. Present only if FleetAutoscalerPolicyType = Wasm.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerPolicyType">FleetAutoscalerPolicyType
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>, 
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerStatus">FleetAutoscalerStatus</a>)
+</p>
+<p>
+<p>FleetAutoscalerPolicyType is the policy for autoscaling
+for a given Fleet</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;Buffer&#34;</p></td>
+<td><p>BufferPolicyType FleetAutoscalerPolicyType is a simple buffering strategy for Ready
+GameServers</p>
+</td>
+</tr><tr><td><p>&#34;Chain&#34;</p></td>
+<td><p>[Stage:Beta]
+[FeatureFlag:ScheduledAutoscaler]
+ChainPolicyType is for Chain based fleet autoscaling
+nolint:revive // Linter contains comment doesn&rsquo;t start with ChainPolicyType</p>
+</td>
+</tr><tr><td><p>&#34;Counter&#34;</p></td>
+<td><p>[Stage:Beta]
+[FeatureFlag:CountsAndLists]
+CounterPolicyType is for Counter based fleet autoscaling
+nolint:revive // Linter contains comment doesn&rsquo;t start with CounterPolicyType</p>
+</td>
+</tr><tr><td><p>&#34;List&#34;</p></td>
+<td><p>[Stage:Beta]
+[FeatureFlag:CountsAndLists]
+ListPolicyType is for List based fleet autoscaling
+nolint:revive // Linter contains comment doesn&rsquo;t start with ListPolicyType</p>
+</td>
+</tr><tr><td><p>&#34;Schedule&#34;</p></td>
+<td><p>[Stage:Beta]
+[FeatureFlag:ScheduledAutoscaler]
+SchedulePolicyType is for Schedule based fleet autoscaling
+nolint:revive // Linter contains comment doesn&rsquo;t start with SchedulePolicyType</p>
+</td>
+</tr><tr><td><p>&#34;Wasm&#34;</p></td>
+<td><p>WasmPolicyType is for WebAssembly based fleet autoscaling
+[Stage:Alpha]
+[FeatureFlag:WasmAutoscaler]</p>
+</td>
+</tr><tr><td><p>&#34;Webhook&#34;</p></td>
+<td><p>WebhookPolicyType is a simple webhook strategy used for horizontal fleet scaling
+GameServers</p>
+</td>
+</tr></tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerSpec">FleetAutoscalerSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscaler">FleetAutoscaler</a>)
+</p>
+<p>
+<p>FleetAutoscalerSpec is the spec for a Fleet Scaler</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>fleetName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>policy</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">
+FleetAutoscalerPolicy
+</a>
+</em>
+</td>
+<td>
+<p>Autoscaling policy</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sync</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSync">
+FleetAutoscalerSync
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Sync defines when FleetAutoscalers runs autoscaling</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerStatus">FleetAutoscalerStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscaler">FleetAutoscaler</a>)
+</p>
+<p>
+<p>FleetAutoscalerStatus defines the current status of a FleetAutoscaler</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>currentReplicas</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>CurrentReplicas is the current number of gameserver replicas
+of the fleet managed by this autoscaler, as last seen by the autoscaler</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>desiredReplicas</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>DesiredReplicas is the desired number of gameserver replicas
+of the fleet managed by this autoscaler, as last calculated by the autoscaler</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lastScaleTime</code><br/>
+<em>
+<a href="https://v1-35.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>lastScaleTime is the last time the FleetAutoscaler scaled the attached fleet,</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ableToScale</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>AbleToScale indicates that we can access the target fleet</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scalingLimited</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>ScalingLimited indicates that the calculated scale would be above or below the range
+defined by MinReplicas and MaxReplicas, and has thus been capped.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lastAppliedPolicy</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicyType">
+FleetAutoscalerPolicyType
+</a>
+</em>
+</td>
+<td>
+<p>LastAppliedPolicy is the ID of the last applied policy in the ChainPolicy.
+Used to track policy transitions for logging purposes.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerSync">FleetAutoscalerSync
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSpec">FleetAutoscalerSpec</a>)
+</p>
+<p>
+<p>FleetAutoscalerSync describes when to sync a fleet</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>type</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSyncType">
+FleetAutoscalerSyncType
+</a>
+</em>
+</td>
+<td>
+<p>Type of autoscaling sync.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>fixedInterval</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.FixedIntervalSync">
+FixedIntervalSync
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>FixedInterval config params. Present only if FleetAutoscalerSyncType = FixedInterval.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.FleetAutoscalerSyncType">FleetAutoscalerSyncType
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerSync">FleetAutoscalerSync</a>)
+</p>
+<p>
+<p>FleetAutoscalerSyncType is the sync strategy for a given Fleet</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;FixedInterval&#34;</p></td>
+<td><p>FixedIntervalSyncType is a simple fixed interval based strategy for trigger autoscaling</p>
+</td>
+</tr></tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.ListPolicy">ListPolicy
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
+</p>
+<p>
+<p>ListPolicy controls the desired behavior of the List autoscaler policy.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>key</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Key is the name of the List. Required field.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>maxCapacity</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<p>MaxCapacity is the maximum aggregate List total capacity across the fleet.
+MaxCapacity must be bigger than both MinCapacity and BufferSize. Required field.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>minCapacity</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<p>MinCapacity is the minimum aggregate List total capacity across the fleet.
+If zero, it is ignored.
+If non zero, it must be smaller than MaxCapacity and bigger than BufferSize.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>bufferSize</code><br/>
+<em>
+k8s.io/apimachinery/pkg/util/intstr.IntOrString
+</em>
+</td>
+<td>
+<p>BufferSize is the size of a buffer based on the List capacity that is available over the
+current aggregate List length in the Fleet (available capacity). It can be specified either
+as an absolute value (i.e. 5) or percentage format (i.e. 5%).
+Must be bigger than 0. Required field.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.SchedulePolicy">SchedulePolicy
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
+</p>
+<p>
+<p>SchedulePolicy controls the desired behavior of the Schedule autoscaler policy.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>between</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.Between">
+Between
+</a>
+</em>
+</td>
+<td>
+<p>Between defines the time period that the policy is eligible to be applied.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>activePeriod</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.ActivePeriod">
+ActivePeriod
+</a>
+</em>
+</td>
+<td>
+<p>ActivePeriod defines the time period that the policy is applied.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>policy</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">
+FleetAutoscalerPolicy
+</a>
+</em>
+</td>
+<td>
+<p>Policy is the name of the policy to be applied. Required field.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.URLConfiguration">URLConfiguration
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>, 
+<a href="#autoscaling.agones.dev/v1.WasmFrom">WasmFrom</a>)
+</p>
+<p>
+<p>URLConfiguration is a generic configuration for any integration with an external URL or
+cluster provided service. For example, it can be used to configure a webhook or Wasm module</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>url</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p><code>url</code> gives the location of the webhook, in standard URL form
+(<code>scheme://host:port/path</code>). Exactly one of <code>url</code> or <code>service</code>
+must be specified.</p>
+<p>The <code>host</code> should not refer to a service running in the cluster; use
+the <code>service</code> field instead. The host might be resolved via external
+DNS in some apiservers (e.g., <code>kube-apiserver</code> cannot resolve
+in-cluster DNS as that would be a layering violation). <code>host</code> may
+also be an IP address.</p>
+<p>Please note that using <code>localhost</code> or <code>127.0.0.1</code> as a <code>host</code> is
+risky unless you take great care to run this webhook on all hosts
+which run an apiserver which might need to make calls to this
+webhook. Such installs are likely to be non-portable, i.e., not easy
+to turn up in a new cluster.</p>
+<p>The scheme must be &ldquo;https&rdquo;; the URL must begin with &ldquo;https://&rdquo;.</p>
+<p>A path is optional, and if present may be any string permissible in
+a URL. You may use the path to pass an arbitrary string to the
+webhook, for example, a cluster identifier.</p>
+<p>Attempting to use a user or basic auth e.g. &ldquo;user:password@&rdquo; is not
+allowed. Fragments (&ldquo;#&hellip;&rdquo;) and query parameters (&ldquo;?&hellip;&rdquo;) are not
+allowed, either.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>service</code><br/>
+<em>
+<a href="https://v1-35.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#servicereference-v1-admissionregistration">
+Kubernetes admissionregistration/v1.ServiceReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p><code>service</code> is a reference to the service for this webhook. Either
+<code>service</code> or <code>url</code> must be specified.</p>
+<p>If the webhook is running within the cluster, then you should use <code>service</code>.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>caBundle</code><br/>
+<em>
+[]byte
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p><code>caBundle</code> is a PEM encoded CA bundle which will be used to validate the webhook&rsquo;s server certificate.
+If unspecified, system trust roots on the apiserver are used.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.WasmFrom">WasmFrom
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.WasmPolicy">WasmPolicy</a>)
+</p>
+<p>
+<p>WasmFrom defines the source of the Wasm module</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>url</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.URLConfiguration">
+URLConfiguration
+</a>
+</em>
+</td>
+<td>
+<p>URL is the URL of the Wasm module to use for autoscaling.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="autoscaling.agones.dev/v1.WasmPolicy">WasmPolicy
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#autoscaling.agones.dev/v1.FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
+</p>
+<p>
+<p>WasmPolicy controls the desired behavior of the Wasm policy.
+It contains the configuration for the WebAssembly module used for autoscaling.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>function</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Function is the exported function to call in the wasm module, defaults to &lsquo;scale&rsquo;</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>config</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Config values to pass to the wasm program on startup</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>from</code><br/>
+<em>
+<a href="#autoscaling.agones.dev/v1.WasmFrom">
+WasmFrom
+</a>
+</em>
+</td>
+<td>
+<p>WasmFrom defines the source of the Wasm module</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>hash</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Hash of the Wasm module, used to verify the integrity of the module</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="multicluster.agones.dev/v1">multicluster.agones.dev/v1</h2>
+<p>
+<p>Package v1 is the v1 version of the API.</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#multicluster.agones.dev/v1.GameServerAllocationPolicy">GameServerAllocationPolicy</a>
+</li></ul>
+<h3 id="multicluster.agones.dev/v1.GameServerAllocationPolicy">GameServerAllocationPolicy
+</h3>
+<p>
+<p>GameServerAllocationPolicy is the Schema for the gameserverallocationpolicies API</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+string</td>
+<td>
+<code>
+multicluster.agones.dev/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br/>
+string
+</td>
+<td><code>GameServerAllocationPolicy</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://v1-35.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#multicluster.agones.dev/v1.GameServerAllocationPolicySpec">
+GameServerAllocationPolicySpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>priority</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>weight</code><br/>
+<em>
+int
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>connectionInfo</code><br/>
+<em>
+<a href="#multicluster.agones.dev/v1.ClusterConnectionInfo">
+ClusterConnectionInfo
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="multicluster.agones.dev/v1.ClusterConnectionInfo">ClusterConnectionInfo
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#multicluster.agones.dev/v1.GameServerAllocationPolicySpec">GameServerAllocationPolicySpec</a>)
+</p>
+<p>
+<p>ClusterConnectionInfo defines the connection information for a cluster</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>clusterName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Optional: the name of the targeted cluster</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>allocationEndpoints</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<p>The endpoints for the allocator service in the targeted cluster.
+If the AllocationEndpoints is not set, the allocation happens on local cluster.
+If there are multiple endpoints any of the endpoints that can handle allocation request should suffice</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>secretName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>The name of the secret that contains TLS client certificates to connect the allocator server in the targeted cluster</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>namespace</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>The cluster namespace from which to allocate gameservers</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serverCa</code><br/>
+<em>
+[]byte
+</em>
+</td>
+<td>
+<p>The PEM encoded server CA, used by the allocator client to authenticate the remote server.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="multicluster.agones.dev/v1.ConnectionInfoIterator">ConnectionInfoIterator
+</h3>
+<p>
+<p>ConnectionInfoIterator an iterator on ClusterConnectionInfo</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>currPriority</code><br/>
+<em>
+int
+</em>
+</td>
+<td>
+<p>currPriority Current priority index from the orderedPriorities</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>orderedPriorities</code><br/>
+<em>
+[]int32
+</em>
+</td>
+<td>
+<p>orderedPriorities list of ordered priorities</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>priorityToCluster</code><br/>
+<em>
+map[int32]map[string][]*agones.dev/agones/pkg/apis/multicluster/v1.GameServerAllocationPolicy
+</em>
+</td>
+<td>
+<p>priorityToCluster Map of priority to cluster-policies map</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>clusterBlackList</code><br/>
+<em>
+map[string]bool
+</em>
+</td>
+<td>
+<p>clusterBlackList the cluster blacklist for the clusters that has already returned</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="multicluster.agones.dev/v1.GameServerAllocationPolicySpec">GameServerAllocationPolicySpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#multicluster.agones.dev/v1.GameServerAllocationPolicy">GameServerAllocationPolicy</a>)
+</p>
+<p>
+<p>GameServerAllocationPolicySpec defines the desired state of GameServerAllocationPolicy</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>priority</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>weight</code><br/>
+<em>
+int
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>connectionInfo</code><br/>
+<em>
+<a href="#multicluster.agones.dev/v1.ClusterConnectionInfo">
+ClusterConnectionInfo
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<p><em>
+Generated with <code>gen-crd-api-reference-docs</code>.
+</em></p>
+{{% /feature %}}
+


### PR DESCRIPTION



<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/agones-dev/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/agones-dev/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/agones-dev/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

The `gameservers.lists.maxItems` Helm value was only ever consumed by the CRD templates, so no Go binary received it. Lacking a configured limit, `UpdateList` called `SDKServer.GsListsMaxItems`, which tried to discover one at runtime by listing the GameServers in the fleet. That implementation discarded the error from its `Get` of the current GameServer, so a failed lookup left the fleet label empty, selected `agones.dev/fleet=`, matched nothing and returned "no gameservers for fleet" - failing every `UpdateList` while `GET`, `AddListValue` and `RemoveListValue` on the same List kept working. It also hardcoded the list name "players" and the fleet label "fleet-example" for the `default` namespace, and did an N+1 List+Get from every sidecar.

Separately, `agonesv1.ListMaxCapacity` hardcoded 1000 as the cap enforced during allocation, a second unsynchronised copy of a number `values.yaml` already owns: raise `maxItems` above 1000 and the CRD accepted a capacity the allocator rejected; lower it below 1000 and the allocator accepted one the API server then refused to persist.

The configured value is now carried to every binary that enforces it, as a `MAX_LIST_ITEMS` env var with the same name at each hop, and injected through constructors rather than package globals:

    values.yaml gameservers.lists.maxItems
      |-> controller  -> sidecar env MAX_LIST_ITEMS -> sdk-server -> NewSDKServer
      |-> extensions  -> NewExtensions -> NewAllocator
      |-> allocator   -> newServiceHandler -> NewAllocator
      `-> processor   -> NewAllocator


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
Use "Work on #<issue number>" if you wish to reference the issue without closing it.
-->
Closes #4680

**Did you use AI tools in preparing this PR?**:
<!--
If you used AI tools in preparing your PR, you must disclose this in the description of your PR.
--->
Y

**Special notes for your reviewer**:

Operations implemented:


- Delete `GsListsMaxItems`, `GsLocalListsMaxItems`, the `GameServerListMaxCapacity` package global and the `agonesv1.ListMaxCapacity` constant.
- `NewSDKServer`, `NewLocalSDKServer`, `NewController`, `NewAllocator` and `NewExtensions` take the limit as a constructor parameter; `UpdateListCapacity` and `ListActions` take it as an argument. The out-of-range errors now report the configured limit rather than a hardcoded 1000.
- Add `minimum: 1` to `gameservers.lists.maxItems` in `values.schema.json`, so Helm rejects a non-positive limit at install time.

Also fixes a pre-existing mismatch found en route: the controller sets the sidecar env var `REQUESTS_RATE_LIMIT`, but cmd/sdk-server declared its flag as `request-rate-limit`, which viper maps to `REQUEST_RATE_LIMIT`. The names never matched, so `agones.sdkServer.requestsRateLimit` never reached the sidecar and it always fell back to the 500ms default. The flag is renamed to `requests-rate-limit`; the env var the controller emits is unchanged.

