### PR TITLE
test: call t.Helper() in shared test helpers

### DIFF
--- a/cmd/controller/main_test.go
+++ b/cmd/controller/main_test.go
@@ -147,6 +147,7 @@ func TestControllerConfigValidationMaxListItems(t *testing.T) {
 }
 
 func errorsContainString(t *testing.T, errs []error, expected string) {
+	t.Helper()
 	found := false
 	for _, v := range errs {
 		if strings.Contains(v.Error(), expected) {

--- a/pkg/fleetautoscalers/controller_test.go
+++ b/pkg/fleetautoscalers/controller_test.go
@@ -788,6 +788,7 @@ func TestControllerSyncFleetAutoscaler(t *testing.T) {
 // this is a sign that the informer has been started and the fleet autoscaler has been processed
 // by the informer.
 func fleetAutoscalerThreadEventually(t *testing.T, c *Controller, fas *autoscalingv1.FleetAutoscaler) {
+	t.Helper()
 	require.Eventually(t, func() bool {
 		c.fasThreadMutex.Lock()
 		defer c.fasThreadMutex.Unlock()

--- a/pkg/gameservers/controller_test.go
+++ b/pkg/gameservers/controller_test.go
@@ -257,6 +257,7 @@ func TestControllerSyncGameServerWithInitSidecar(t *testing.T) {
 }
 
 func runReconcileDeleteGameServer(t *testing.T, fixture *agonesv1.GameServer) {
+	t.Helper()
 	c, mocks := newFakeController()
 	agonesWatch := watch.NewFake()
 	podAction := false
@@ -2518,6 +2519,7 @@ func TestControllerAddSDKServerEnvVars(t *testing.T) {
 // testNoChange runs a test with a state that doesn't exist, to ensure a handler
 // doesn't do process anything beyond the state it is meant to handle.
 func testNoChange(t *testing.T, state agonesv1.GameServerState, f func(*Controller, *agonesv1.GameServer) (*agonesv1.GameServer, error)) {
+	t.Helper()
 	c, mocks := newFakeController()
 	fixture := &agonesv1.GameServer{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
 		Spec: newSingleContainerSpec(), Status: agonesv1.GameServerStatus{State: state}}
@@ -2537,6 +2539,7 @@ func testNoChange(t *testing.T, state agonesv1.GameServerState, f func(*Controll
 // testWithNonZeroDeletionTimestamp runs a test with a given state, but
 // the DeletionTimestamp set to Now()
 func testWithNonZeroDeletionTimestamp(t *testing.T, f func(*Controller, *agonesv1.GameServer) (*agonesv1.GameServer, error)) {
+	t.Helper()
 	c, mocks := newFakeController()
 	now := metav1.Now()
 	fixture := &agonesv1.GameServer{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", DeletionTimestamp: &now},

--- a/pkg/metrics/exporter_test.go
+++ b/pkg/metrics/exporter_test.go
@@ -200,6 +200,7 @@ func newMockWithReactorNodesAndGameServers() agtesting.Mocks {
 }
 
 func setupGameServer(t *testing.T, ctrl *fakeController) {
+	t.Helper()
 	gs := gameServerWithFleetAndState("test-fleet", agonesv1.GameServerStateCreating)
 	ctrl.gsWatch.Add(gs)
 
@@ -254,6 +255,7 @@ func setupFleetWithCountersAndLists(_ *testing.T, ctrl *fakeController) {
 }
 
 func setupGameServerPlayerConnect(t *testing.T, ctrl *fakeController) {
+	t.Helper()
 	gs := gameServerWithFleetAndState("test-fleet", agonesv1.GameServerStateReady)
 	gs.Status.Players = &agonesv1.PlayerStatus{
 		Count: 0,
@@ -275,6 +277,7 @@ func setupGameServerPlayerConnect(t *testing.T, ctrl *fakeController) {
 }
 
 func setupGameServerAllocation(t *testing.T, ctrl *fakeController) {
+	t.Helper()
 	gs := gameServerWithFleetAndState("test-fleet", agonesv1.GameServerStateCreating)
 	ctrl.gsWatch.Add(gs)
 	gs = gs.DeepCopy()

--- a/pkg/metrics/util_test.go
+++ b/pkg/metrics/util_test.go
@@ -82,6 +82,7 @@ func (c *fakeController) close() {
 }
 
 func (c *fakeController) run(t *testing.T) {
+	t.Helper()
 	go func() {
 		err := c.Controller.Run(c.ctx, 1)
 		assert.NoError(t, err)

--- a/pkg/sdkserver/helper_test.go
+++ b/pkg/sdkserver/helper_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func testHTTPHealth(t *testing.T, url string, expectedResponse string, expectedStatus int) {
+	t.Helper()
 	// do a poll, because this code could run before the health check becomes live
 	err := wait.PollUntilContextTimeout(context.Background(), time.Second, 20*time.Second, true, func(_ context.Context) (done bool, err error) {
 		resp, err := http.Get(url)

--- a/pkg/sdkserver/localsdk_test.go
+++ b/pkg/sdkserver/localsdk_test.go
@@ -1075,6 +1075,7 @@ func gsToTmpFile(gs *agonesv1.GameServer) (string, error) {
 
 // assertWatchUpdate checks the values of an update message when a GameServer value has been changed
 func assertWatchUpdate(t *testing.T, stream *gameServerMockStream, expected any, actual func(gs *sdk.GameServer) any) {
+	t.Helper()
 	select {
 	case msg := <-stream.msgs:
 		assert.Equal(t, expected, actual(msg))
@@ -1085,6 +1086,7 @@ func assertWatchUpdate(t *testing.T, stream *gameServerMockStream, expected any,
 
 // assertNoWatchUpdate checks that no update message has been sent for changes to the GameServer
 func assertNoWatchUpdate(t *testing.T, stream *gameServerMockStream) {
+	t.Helper()
 	select {
 	case <-stream.msgs:
 		assert.Fail(t, "should not get a message")
@@ -1094,6 +1096,7 @@ func assertNoWatchUpdate(t *testing.T, stream *gameServerMockStream) {
 
 // assertInitialWatchUpdate checks that the initial GameServer state is sent immediately after WatchGameServer
 func assertInitialWatchUpdate(t *testing.T, stream *gameServerMockStream) {
+	t.Helper()
 	select {
 	case <-stream.msgs:
 	case <-time.After(time.Second):

--- a/pkg/sdkserver/sdkserver_test.go
+++ b/pkg/sdkserver/sdkserver_test.go
@@ -56,6 +56,7 @@ const defaultTestListMaxCapacity = int64(1000)
 // patchGameServer is a helper function for the AddReactor "patch" that creates and applies a patch
 // to a gameserver. Returns a patched copy and does not modify the original game server.
 func patchGameServer(t *testing.T, action k8stesting.Action, gs *agonesv1.GameServer) *agonesv1.GameServer {
+	t.Helper()
 	pa := action.(k8stesting.PatchAction)
 	patchJSON := pa.GetPatch()
 	patch, err := jsonpatch.DecodePatch(patchJSON)
@@ -2094,6 +2095,7 @@ func waitConnectedStreamCount(sc *SDKServer, count int) error { //nolint:unparam
 }
 
 func asyncWatchGameServer(t *testing.T, sc *SDKServer, stream sdk.SDK_WatchGameServerServer) {
+	t.Helper()
 	// Note that WatchGameServer() uses getGameServer() and would block
 	// if gsWaitForSync is not Done().
 	go func() {

--- a/pkg/testing/controller.go
+++ b/pkg/testing/controller.go
@@ -91,6 +91,7 @@ func NewEstablishedCRD() *apiextv1.CustomResourceDefinition {
 // AssertEventContains asserts that a k8s event stream contains a
 // value, and assert.FailNow() if it does not
 func AssertEventContains(t *gotesting.T, events <-chan string, contains string) {
+	t.Helper()
 	select {
 	case e := <-events:
 		assert.Contains(t, e, contains)
@@ -102,6 +103,7 @@ func AssertEventContains(t *gotesting.T, events <-chan string, contains string) 
 // AssertNoEvent asserts that the event stream does not
 // have a value in it (at least in the next second)
 func AssertNoEvent(t *gotesting.T, events <-chan string) {
+	t.Helper()
 	select {
 	case e := <-events:
 		assert.Fail(t, "should not have an event", e)

--- a/test/e2e/allochelper/helper_func.go
+++ b/test/e2e/allochelper/helper_func.go
@@ -77,6 +77,7 @@ const (
 
 // CopyDefaultAllocatorClientSecret copys the allocator client secret
 func CopyDefaultAllocatorClientSecret(ctx context.Context, t *testing.T, toNamespace string, framework *e2e.Framework) {
+	t.Helper()
 	kubeCore := framework.KubeClient.CoreV1()
 	clientSecret, err := kubeCore.Secrets(allocatorClientSecretNamespace).Get(ctx, allocatorClientSecretName, metav1.GetOptions{})
 	if err != nil {
@@ -104,6 +105,7 @@ func CreateAllocationPolicy(ctx context.Context, t *testing.T, framework *e2e.Fr
 
 // GetAllocatorEndpoint gets the allocator LB endpoint
 func GetAllocatorEndpoint(ctx context.Context, t *testing.T, framework *e2e.Framework) (string, int32) {
+	t.Helper()
 	kubeCore := framework.KubeClient.CoreV1()
 	svc, err := kubeCore.Services(agonesSystemNamespace).Get(ctx, allocatorServiceName, metav1.GetOptions{})
 	if !assert.NoError(t, err) {
@@ -299,6 +301,7 @@ func DeleteAgonesPod(ctx context.Context, podName string, namespace string, fram
 // a client that has at least once successfully allocated from a fleet. The fleet used to test
 // the client is leaked.
 func GetAllocatorClient(ctx context.Context, t *testing.T, framework *e2e.Framework) (pb.AllocationServiceClient, error) {
+	t.Helper()
 	logger := e2e.TestLogger(t)
 	ip, port := GetAllocatorEndpoint(ctx, t, framework)
 	requestURL := fmt.Sprintf(allocatorReqURLFmt, ip, port)

--- a/test/e2e/extensions/high_availability_test.go
+++ b/test/e2e/extensions/high_availability_test.go
@@ -97,6 +97,7 @@ func TestGameServerCreationRightAfterDeletingOneExtensionsPod(t *testing.T) {
 // deleteAgonesExtensionsPod deletes one of the extensions pod for the Agones extensions,
 // faking a extensions pod crash.
 func deleteAgonesExtensionsPod(ctx context.Context, t *testing.T, waitForExtensions bool) {
+	t.Helper()
 	list, err := getAgonesExtensionsPods(ctx)
 	require.NoError(t, err, "Could not get list of Extension pods")
 

--- a/test/e2e/fleet_test.go
+++ b/test/e2e/fleet_test.go
@@ -985,6 +985,7 @@ func TestFleetNameValidation(t *testing.T) {
 }
 
 func assertSuccessOrUpdateConflict(t *testing.T, err error) {
+	t.Helper()
 	if !k8serrors.IsConflict(err) {
 		// update conflicts are sometimes ok, we simply lost the race.
 		require.NoError(t, err)
@@ -1895,6 +1896,7 @@ func TestFleetAllocationOverflow(t *testing.T) {
 }
 
 func assertCausesContainsString(t *testing.T, causes []metav1.StatusCause, expected string) {
+	t.Helper()
 	strs := make([]string, 0, len(causes))
 	for _, v := range causes {
 		strs = append(strs, v.Message)
@@ -1921,6 +1923,7 @@ func countFleetScheduling(gsList []agonesv1.GameServer, scheduling apis.Scheduli
 
 // Patches fleet with scheduling and scale values
 func schedulingFleetPatch(ctx context.Context, t *testing.T, f *agonesv1.Fleet, scheduling apis.SchedulingStrategy, scale int32) *agonesv1.Fleet {
+	t.Helper()
 
 	patch := fmt.Sprintf(`[{ "op": "replace", "path": "/spec/scheduling", "value": "%s" },
 	                       { "op": "replace", "path": "/spec/replicas", "value": %d }]`,
@@ -1942,6 +1945,7 @@ func schedulingFleetPatch(ctx context.Context, t *testing.T, f *agonesv1.Fleet, 
 }
 
 func scaleAndWait(ctx context.Context, t *testing.T, flt *agonesv1.Fleet, fleetSize int32) (duration time.Duration, err error) {
+	t.Helper()
 	t0 := time.Now()
 	scaleFleetSubresource(ctx, t, flt, fleetSize)
 	err = framework.WaitForFleetCondition(t, flt, e2e.FleetReadyCount(fleetSize))
@@ -1952,6 +1956,7 @@ func scaleAndWait(ctx context.Context, t *testing.T, flt *agonesv1.Fleet, fleetS
 // scaleFleetPatch creates a patch to apply to a Fleet.
 // Easier for testing, as it removes object generational issues.
 func scaleFleetPatch(ctx context.Context, t *testing.T, f *agonesv1.Fleet, scale int32) *agonesv1.Fleet {
+	t.Helper()
 	patch := fmt.Sprintf(`[{ "op": "replace", "path": "/spec/replicas", "value": %d }]`, scale)
 	logrus.WithField("fleet", f.ObjectMeta.Name).WithField("scale", scale).WithField("patch", patch).Info("Scaling fleet")
 
@@ -1963,6 +1968,7 @@ func scaleFleetPatch(ctx context.Context, t *testing.T, f *agonesv1.Fleet, scale
 // scaleFleetSubresource uses scale subresource to change Replicas size of the Fleet.
 // Returns the same f as in parameter, just to keep signature in sync with scaleFleetPatch
 func scaleFleetSubresource(ctx context.Context, t *testing.T, f *agonesv1.Fleet, scale int32) *agonesv1.Fleet {
+	t.Helper()
 	logrus.WithField("fleet", f.ObjectMeta.Name).WithField("scale", scale).Info("Scaling fleet")
 
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {

--- a/test/e2e/fleetautoscaler_test.go
+++ b/test/e2e/fleetautoscaler_test.go
@@ -2186,6 +2186,7 @@ func TestWasmAutoScaler(t *testing.T) {
 
 // defaultAutoscalerSchedule returns a default scheduled autoscaler for testing.
 func defaultAutoscalerSchedule(t *testing.T, f *agonesv1.Fleet) *autoscalingv1.FleetAutoscaler {
+	t.Helper()
 	return &autoscalingv1.FleetAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      f.ObjectMeta.Name + "-scheduled-autoscaler",
@@ -2227,6 +2228,7 @@ func defaultAutoscalerSchedule(t *testing.T, f *agonesv1.Fleet) *autoscalingv1.F
 
 // defaultAutoscalerChain returns a default chain autoscaler for testing.
 func defaultAutoscalerChain(t *testing.T, f *agonesv1.Fleet) *autoscalingv1.FleetAutoscaler {
+	t.Helper()
 	return &autoscalingv1.FleetAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      f.ObjectMeta.Name + "-chain-autoscaler",
@@ -2331,6 +2333,7 @@ func nextCronMinuteBetween(currentTime time.Time) string {
 
 // Parse a duration string and return a duration struct
 func mustParseDuration(t *testing.T, duration string) time.Duration {
+	t.Helper()
 	d, err := time.ParseDuration(duration)
 	assert.NoError(t, err)
 	return d
@@ -2338,6 +2341,7 @@ func mustParseDuration(t *testing.T, duration string) time.Duration {
 
 // Parse a time string and return a metav1.Time
 func currentTimePlusDuration(t *testing.T, duration string) metav1.Time {
+	t.Helper()
 	d := mustParseDuration(t, duration)
 	currentTimePlusDuration := time.Now().Add(d)
 	return metav1.NewTime(currentTimePlusDuration)
@@ -2347,6 +2351,7 @@ func currentTimePlusDuration(t *testing.T, duration string) metav1.Time {
 // Needs kubectl to be on the file path.
 // May want to replace this with a more robust solution using the Kubernetes client-go library at some point, but since all e2e tests use kubectl, this is a quick solution.
 func copyFileToContainer(t *testing.T, namespace, podName, containerName, srcPath, destPath string) error {
+	t.Helper()
 	cmd := exec.Command("kubectl", "cp", srcPath, fmt.Sprintf("%s/%s:%s", namespace, podName, destPath), "-c", containerName)
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -311,6 +311,7 @@ func (f *Framework) WaitForGameServerState(t *testing.T, gs *agonesv1.GameServer
 // Each Allocated GameServer gets deleted allocDuration after it was Allocated.
 // GameServers will continue to be Allocated until a message is passed to the done channel.
 func (f *Framework) CycleAllocations(ctx context.Context, t *testing.T, flt *agonesv1.Fleet, period time.Duration, allocDuration time.Duration) {
+	t.Helper()
 	err := wait.PollUntilContextCancel(ctx, period, true, func(_ context.Context) (bool, error) {
 		gsa := GetAllocation(flt)
 		gsa, err := f.AgonesClient.AllocationV1().GameServerAllocations(flt.Namespace).Create(context.Background(), gsa, metav1.CreateOptions{})
@@ -336,6 +337,7 @@ func (f *Framework) CycleAllocations(ctx context.Context, t *testing.T, flt *ago
 
 // ScaleFleet will scale a Fleet with retries to a specified replica size.
 func (f *Framework) ScaleFleet(t *testing.T, log *logrus.Entry, flt *agonesv1.Fleet, replicas int32) {
+	t.Helper()
 	fleets := f.AgonesClient.AgonesV1().Fleets(f.Namespace)
 	ctx := context.Background()
 
@@ -360,12 +362,14 @@ func (f *Framework) ScaleFleet(t *testing.T, log *logrus.Entry, flt *agonesv1.Fl
 
 // AssertFleetCondition waits for the Fleet to be in a specific condition or fails the test if the condition can't be met in 5 minutes.
 func (f *Framework) AssertFleetCondition(t *testing.T, flt *agonesv1.Fleet, condition func(*logrus.Entry, *agonesv1.Fleet) bool) {
+	t.Helper()
 	err := f.WaitForFleetCondition(t, flt, condition)
 	require.NoError(t, err, "error waiting for fleet condition on fleet: %v", flt.Name)
 }
 
 // WaitForFleetCondition waits for the Fleet to be in a specific condition or returns an error if the condition can't be met in 5 minutes.
 func (f *Framework) WaitForFleetCondition(t *testing.T, flt *agonesv1.Fleet, condition func(*logrus.Entry, *agonesv1.Fleet) bool) error {
+	t.Helper()
 	log := TestLogger(t).WithField("fleet", flt.Name)
 	log.Info("waiting for fleet condition")
 	err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, f.WaitForState, true, func(_ context.Context) (bool, error) {
@@ -402,6 +406,7 @@ func (f *Framework) WaitForFleetCondition(t *testing.T, flt *agonesv1.Fleet, con
 // WaitForFleetAutoScalerCondition waits for the FleetAutoscaler to be in a specific condition or fails the test if the condition can't be met in 2 minutes.
 // nolint: dupl
 func (f *Framework) WaitForFleetAutoScalerCondition(t *testing.T, fas *autoscaling.FleetAutoscaler, condition func(log *logrus.Entry, fas *autoscaling.FleetAutoscaler) bool) {
+	t.Helper()
 	log := TestLogger(t).WithField("fleetautoscaler", fas.Name)
 	log.Info("waiting for fleetautoscaler condition")
 	err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 2*time.Minute, true, func(_ context.Context) (bool, error) {
@@ -529,6 +534,7 @@ func (f *Framework) CleanUp(ns string) error {
 
 // CreateAndApplyAllocation creates and applies an Allocation to a Fleet
 func (f *Framework) CreateAndApplyAllocation(t *testing.T, flt *agonesv1.Fleet) *allocationv1.GameServerAllocation {
+	t.Helper()
 	gsa := GetAllocation(flt)
 	gsa, err := f.AgonesClient.AllocationV1().GameServerAllocations(flt.ObjectMeta.Namespace).Create(context.Background(), gsa, metav1.CreateOptions{})
 	require.NoError(t, err)
@@ -540,6 +546,7 @@ func (f *Framework) CreateAndApplyAllocation(t *testing.T, flt *agonesv1.Fleet) 
 // finds the first udp port from the spec to send the message to,
 // returns error if no Ports were allocated
 func (f *Framework) SendGameServerUDP(t *testing.T, gs *agonesv1.GameServer, msg string) (string, error) {
+	t.Helper()
 	if len(gs.Status.Ports) == 0 {
 		return "", f.errs.New("Empty Ports array")
 	}
@@ -556,6 +563,7 @@ func (f *Framework) SendGameServerUDP(t *testing.T, gs *agonesv1.GameServer, msg
 // SendGameServerUDPToPort sends a message to a gameserver at the named port and returns its reply
 // returns error if no Ports were allocated or a port of the specified name doesn't exist
 func (f *Framework) SendGameServerUDPToPort(t *testing.T, gs *agonesv1.GameServer, portName string, msg string) (string, error) {
+	t.Helper()
 	log := TestLogger(t)
 	if len(gs.Status.Ports) == 0 {
 		return "", f.errs.New("Empty Ports array")
@@ -580,6 +588,7 @@ func (f *Framework) SendGameServerUDPToPort(t *testing.T, gs *agonesv1.GameServe
 // SendUDP sends a message to an address, and returns its reply if
 // it returns one in 10 seconds. Will retry 5 times, in case UDP packets drop.
 func (f *Framework) SendUDP(t *testing.T, address, msg string) (string, error) {
+	t.Helper()
 	log := TestLogger(t).WithField("address", address)
 	b := make([]byte, 1024)
 	var n int
@@ -915,6 +924,7 @@ func (f *Framework) DefaultGameServer(namespace string) *agonesv1.GameServer {
 // LogEvents logs all the events for a given Kubernetes objects. Useful for debugging why something
 // went wrong.
 func (f *Framework) LogEvents(t *testing.T, log *logrus.Entry, namespace string, objOrRef k8sruntime.Object) {
+	t.Helper()
 	log.WithField("kind", objOrRef.GetObjectKind().GroupVersionKind().Kind).Info("Dumping Events:")
 	events, err := f.KubeClient.CoreV1().Events(namespace).SearchWithContext(context.Background(), scheme.Scheme, objOrRef)
 	require.NoError(t, err, "error searching for events")
@@ -927,6 +937,7 @@ func (f *Framework) LogEvents(t *testing.T, log *logrus.Entry, namespace string,
 // LogPodContainers takes a Pod as an argument and attempts to output the current and previous logs from each container
 // in that Pod It uses the framework's KubeClient to retrieve the logs and outputs them using the provided logger.
 func (f *Framework) LogPodContainers(t *testing.T, pod *corev1.Pod) {
+	t.Helper()
 	log := TestLogger(t)
 	log.WithField("pod", pod.Name).WithField("namespace", pod.Namespace).Info("Logs for Pod:")
 
@@ -978,6 +989,7 @@ func (f *Framework) LogPodContainers(t *testing.T, pod *corev1.Pod) {
 
 // SkipOnCloudProduct skips the test if the e2e was invoked with --cloud-product=<product>.
 func (f *Framework) SkipOnCloudProduct(t *testing.T, product, reason string) {
+	t.Helper()
 	if f.CloudProduct == product {
 		t.Skipf("skipping test on cloud product %s: %s", product, reason)
 	}

--- a/test/e2e/ping_test.go
+++ b/test/e2e/ping_test.go
@@ -97,6 +97,7 @@ func TestPingUDP(t *testing.T) {
 }
 
 func externalIP(t *testing.T, kubeCore typedv1.NodesGetter, svc *corev1.Service) (string, error) {
+	t.Helper()
 	externalIP := ""
 	ctx := context.Background()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/agones-dev/agones/blob/main/CONTRIBUTING.md and developer guide https://github.com/agones-dev/agones/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/agones-dev/agones/blob/main/build/README.md#testing-and-building
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix
> /kind release

**What this PR does / Why we need it**:

Deliberately not a linter change. thelper flags 112 sites, but 67 of those are the per-case closures in table-driven tests, where t.Helper() makes the output strictly worse: those closures each have exactly one caller -- the dispatch line in the test loop -- so marking them as helpers collapses every case's failure onto that single line instead of the assertion that actually failed. In allocation_cache_test.go all nine cases would report line 192.

thelper has no setting that distinguishes a shared helper from a table closure (its only knobs are test.first/name/begin), so enabling it would mean either accepting those 67 or writing 67 suppressions. Neither is worth it for a rule that is a debugging convenience rather than a correctness gate.

So - we're not enabling thelper linting, but we'll merge the good parts in.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
Use "Work on #<issue number>" if you wish to reference the issue without closing it.
-->
Work on #4421

**Did you use AI tools in preparing this PR?**:
<!--
If you used AI tools in preparing your PR, you must disclose this in the description of your PR.
--->
Y/N

**Special notes for your reviewer**:

N/A
